### PR TITLE
Remove class constants from element factory constructors

### DIFF
--- a/s4/clarity/_internal/factory.py
+++ b/s4/clarity/_internal/factory.py
@@ -43,7 +43,7 @@ class ElementFactory(object):
     def _strip_params(string):
         return ElementFactory._params_re.sub('', string)
 
-    def __init__(self, lims, element_class, request_path=None, name_attribute="name"):
+    def __init__(self, lims, element_class):
         """
         :type lims: LIMS
         :type element_class: classobj
@@ -56,17 +56,19 @@ class ElementFactory(object):
 
         self.lims = lims
         self.element_class = element_class
-        self.name_attribute = name_attribute
+        self.name_attribute = self._get_name_attribute()
         self.batch_flags = self._get_batch_flag()
         self._plural_name = self.element_class.__name__.lower() + "s"
-
-        if request_path is None:
-            request_path = "/" + self._plural_name
-        self.uri = lims.root_uri + request_path
+        self.uri = self._get_endpoint_uri()
 
         self._cache = dict()
 
         lims.factories[element_class] = self
+
+    def _get_name_attribute(self):
+        if hasattr(self.element_class, 'NAME_ATTRIBUTE'):
+            return self.element_class.NAME_ATTRIBUTE
+        return "name"
 
     def _get_endpoint_uri(self):
         # type: () -> str

--- a/s4/clarity/_internal/factory.py
+++ b/s4/clarity/_internal/factory.py
@@ -43,7 +43,7 @@ class ElementFactory(object):
     def _strip_params(string):
         return ElementFactory._params_re.sub('', string)
 
-    def __init__(self, lims, element_class, batch_flags=None, request_path=None, name_attribute="name"):
+    def __init__(self, lims, element_class, request_path=None, name_attribute="name"):
         """
         :type lims: LIMS
         :type element_class: classobj
@@ -58,7 +58,7 @@ class ElementFactory(object):
         self.lims = lims
         self.element_class = element_class
         self.name_attribute = name_attribute
-        self.batch_flags = batch_flags or BatchFlags.NONE
+        self.batch_flags = self._get_batch_flag()
         self._plural_name = self.element_class.__name__.lower() + "s"
 
         if request_path is None:
@@ -68,6 +68,19 @@ class ElementFactory(object):
         self._cache = dict()
 
         lims.factories[element_class] = self
+
+    def _get_batch_flag(self):
+        # type: () -> BatchFlags
+        """
+        Reads the batch flag attribute from the element class.
+        This will be defined on the BATCH_FLAGS class property.
+        If this is not defined it is assumed there is no batching.
+        :return: The class's batch flags.
+        """
+
+        if has_attribute(self.element_class, 'BATCH_FLAGS'):
+            return self.element_class.BATCH_FLAGS
+        return BatchFlags.None
 
     def new(self, **kwargs):
         # type: (**str) -> ClarityElement
@@ -146,7 +159,7 @@ class ElementFactory(object):
         return self.batch_flags & BatchFlags.QUERY
 
     def from_link_node(self, xml_node):
-        # type: (ETree.Element) -> ClarityElement
+        # type: (ETree.Element) -> ClarityElement or None
         """
         Will return the ClarityElement described by the link node.
 

--- a/s4/clarity/_internal/factory.py
+++ b/s4/clarity/_internal/factory.py
@@ -47,7 +47,6 @@ class ElementFactory(object):
         """
         :type lims: LIMS
         :type element_class: classobj
-        :type batch_flags: BatchFlags or None
         :type request_path: str
         :param request_path: for example, '/configuration/workflows'.
                              when not specified, uses '/<plural of element name>'.
@@ -69,8 +68,28 @@ class ElementFactory(object):
 
         lims.factories[element_class] = self
 
+    def _get_endpoint_uri(self):
+        # type: () -> str
+        """
+        Returns the Clarity endpoint URI the factory will manage.
+        :return: The fully qualified endpoint URI for this data type.
+        """
+
+        # If the class has the REQUEST_PATH attribute then it will
+        # be used to override the default path.
+        if hasattr(self.element_class, 'REQUEST_PATH'):
+            request_path = self.element_class.REQUEST_PATH
+        else:
+            # The default is the plural name, ex:
+            # /api/v2/steps
+            request_path = "/" + self._plural_name
+
+        # Generate our uri with the request path
+        # in relation to the root uri
+        return self.lims.root_uri + request_path
+
     def _get_batch_flag(self):
-        # type: () -> BatchFlags
+        # type: () -> int
         """
         Reads the batch flag attribute from the element class.
         This will be defined on the BATCH_FLAGS class property.
@@ -78,9 +97,9 @@ class ElementFactory(object):
         :return: The class's batch flags.
         """
 
-        if has_attribute(self.element_class, 'BATCH_FLAGS'):
+        if hasattr(self.element_class, 'BATCH_FLAGS'):
             return self.element_class.BATCH_FLAGS
-        return BatchFlags.None
+        return BatchFlags.NONE
 
     def new(self, **kwargs):
         # type: (**str) -> ClarityElement

--- a/s4/clarity/_internal/factory.py
+++ b/s4/clarity/_internal/factory.py
@@ -45,13 +45,20 @@ class ElementFactory(object):
 
     def __init__(self, lims, element_class):
         """
+        Creates a new factory to provide interface between Clarity LIMS and the client software.
+        The provided `element_class` will be used to convert the XML records into Python objects
+        and back. There are several class attributes that can be set to configure this interface.
+
+        NAME_ATTRIBUTE: This is used if the name of the class differs from the name in the Clarity API
+
+        REQUEST_PATH: If the class has the REQUEST_PATH attribute then it will
+        be used to override the default path. It is used in relation to the root URI of the Clarity API.
+
+        BATCH_FLAGS: Batch Flags use the BitField enumeration to create a bit field that is used
+        to determine what batch services are provided for this data type. It defaults to None.
+
         :type lims: LIMS
         :type element_class: classobj
-        :type request_path: str
-        :param request_path: for example, '/configuration/workflows'.
-                             when not specified, uses '/<plural of element name>'.
-        :type name_attribute: str
-        :param name_attribute: if not "name", provide this to adjust behaviour of 'get_by_name'.
         """
 
         self.lims = lims
@@ -156,28 +163,28 @@ class ElementFactory(object):
         """
         Indicates if Clarity will allow batch get requests.
         """
-        return self.batch_flags & BatchFlags.BATCH_GET
+        return bool(self.batch_flags & BatchFlags.BATCH_GET)
 
     def can_batch_update(self):
         # type: () -> bool
         """
         Indicates if Clarity will allow batch updates.
         """
-        return self.batch_flags & BatchFlags.BATCH_UPDATE
+        return bool(self.batch_flags & BatchFlags.BATCH_UPDATE)
 
     def can_batch_create(self):
         # type: () -> bool
         """
         Indicates if Clarity will allow batch record creation.
         """
-        return self.batch_flags & BatchFlags.BATCH_CREATE
+        return bool(self.batch_flags & BatchFlags.BATCH_CREATE)
 
     def can_query(self):
         # type: () -> bool
         """
         Indicates if Clarity will allow the user to submit queries.
         """
-        return self.batch_flags & BatchFlags.QUERY
+        return bool(self.batch_flags & BatchFlags.QUERY)
 
     def from_link_node(self, xml_node):
         # type: (ETree.Element) -> ClarityElement or None

--- a/s4/clarity/artifact.py
+++ b/s4/clarity/artifact.py
@@ -34,6 +34,7 @@ class Artifact(FieldsMixin, ClarityElement):
     Reference: https://www.genologics.com/files/permanent/API/latest/data_art.html#artifact
     """
     UNIVERSAL_TAG = "{http://genologics.com/ri/artifact}artifact"
+    BATCH_FLAGS = BatchFlags.BATCH_ALL & ~BatchFlags.BATCH_CREATE
 
     type = subnode_property("type")
     output_type = subnode_property("output-type")

--- a/s4/clarity/artifact.py
+++ b/s4/clarity/artifact.py
@@ -1,6 +1,6 @@
 # Copyright 2016 Semaphore Solutions, Inc.
 # ---------------------------------------------------------------------------
-
+from s4.clarity._internal.factory import BatchFlags
 from ._internal import WrappedXml, FieldsMixin, ClarityElement
 from ._internal.props import subnode_property, subnode_element_list, attribute_property, subnode_link
 from s4.clarity.file import File

--- a/s4/clarity/configuration/process_type.py
+++ b/s4/clarity/configuration/process_type.py
@@ -8,6 +8,7 @@ from s4.clarity._internal.props import subnode_property, subnode_property_list_o
 
 class ProcessType(s4.clarity._internal.ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/processtype}process-type"
+    BATCH_FLAGS = BatchFlags.QUERY
 
     inputs = subnode_property_list_of_dicts('process-input', as_attributes=["name"])
 
@@ -33,6 +34,7 @@ class ProcessType(s4.clarity._internal.ClarityElement):
 
 class ProcessTemplate(s4.clarity._internal.FieldsMixin, s4.clarity._internal.ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/processtemplate}process-template"
+    BATCH_FLAGS = BatchFlags.QUERY
 
     type = subnode_link(ProcessType, 'type', attributes=('uri',))
 
@@ -42,6 +44,7 @@ class ProcessTemplate(s4.clarity._internal.FieldsMixin, s4.clarity._internal.Cla
 
 class Automation(s4.clarity._internal.ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/automation}automation"
+    BATCH_FLAGS = BatchFlags.QUERY
 
     name = attribute_property('name')
     context = subnode_property('context')

--- a/s4/clarity/configuration/process_type.py
+++ b/s4/clarity/configuration/process_type.py
@@ -3,12 +3,14 @@
 
 import s4.clarity._internal
 from s4.clarity import types
+from s4.clarity._internal.factory import BatchFlags
 from s4.clarity._internal.props import subnode_property, subnode_property_list_of_dicts, subnode_link, subnode_links, attribute_property
 
 
 class ProcessType(s4.clarity._internal.ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/processtype}process-type"
     BATCH_FLAGS = BatchFlags.QUERY
+    NAME_ATTRIBUTE = "displayname"
 
     inputs = subnode_property_list_of_dicts('process-input', as_attributes=["name"])
 
@@ -45,6 +47,7 @@ class ProcessTemplate(s4.clarity._internal.FieldsMixin, s4.clarity._internal.Cla
 class Automation(s4.clarity._internal.ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/automation}automation"
     BATCH_FLAGS = BatchFlags.QUERY
+    REQUEST_PATH = "/configuration/automations"
 
     name = attribute_property('name')
     context = subnode_property('context')

--- a/s4/clarity/configuration/protocol.py
+++ b/s4/clarity/configuration/protocol.py
@@ -2,6 +2,7 @@
 # ---------------------------------------------------------------------------
 
 from s4.clarity._internal.element import ClarityElement, WrappedXml
+from s4.clarity._internal.factory import BatchFlags
 from s4.clarity.reagent_kit import ReagentKit
 from s4.clarity.control_type import ControlType
 from s4.clarity._internal.props import subnode_property_list_of_dicts, subnode_property, subnode_property_literal_dict, attribute_property, subnode_element_list
@@ -11,6 +12,7 @@ from s4.clarity import types, lazy_property
 class Protocol(ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/protocolconfiguration}protocol"
     BATCH_FLAGS = BatchFlags.QUERY
+    REQUEST_PATH = '/configuration/protocols'
 
     properties = subnode_property_literal_dict('protocol-properties', 'protocol-property')
     index = attribute_property("index", typename=types.NUMERIC)

--- a/s4/clarity/configuration/protocol.py
+++ b/s4/clarity/configuration/protocol.py
@@ -10,6 +10,7 @@ from s4.clarity import types, lazy_property
 
 class Protocol(ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/protocolconfiguration}protocol"
+    BATCH_FLAGS = BatchFlags.QUERY
 
     properties = subnode_property_literal_dict('protocol-properties', 'protocol-property')
     index = attribute_property("index", typename=types.NUMERIC)

--- a/s4/clarity/configuration/udf.py
+++ b/s4/clarity/configuration/udf.py
@@ -2,6 +2,7 @@
 # ---------------------------------------------------------------------------
 from s4.clarity import ETree
 from s4.clarity._internal import ClarityElement
+from s4.clarity._internal.factory import BatchFlags
 from s4.clarity._internal.props import subnode_property, attribute_property
 from s4.clarity import types
 
@@ -10,6 +11,7 @@ class Udf(ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/configuration}udfconfig"
     CREATION_TAG = "{http://genologics.com/ri/configuration}field"
     BATCH_FLAGS = BatchFlags.QUERY
+    REQUEST_PATH = '/configuration/udfs'
 
     # Alternate name to avoid collision with built-in 'type'
     field_type = attribute_property("type") # type: str

--- a/s4/clarity/configuration/udf.py
+++ b/s4/clarity/configuration/udf.py
@@ -9,6 +9,7 @@ from s4.clarity import types
 class Udf(ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/configuration}udfconfig"
     CREATION_TAG = "{http://genologics.com/ri/configuration}field"
+    BATCH_FLAGS = BatchFlags.QUERY
 
     # Alternate name to avoid collision with built-in 'type'
     field_type = attribute_property("type") # type: str

--- a/s4/clarity/configuration/workflow.py
+++ b/s4/clarity/configuration/workflow.py
@@ -8,6 +8,7 @@ from s4.clarity.routing import Router
 
 class Workflow(ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/workflowconfiguration}workflow"
+    BATCH_FLAGS = BatchFlags.QUERY
 
     PENDING_STATUS = "PENDING"
     ACTIVE_STATUS = "ACTIVE"

--- a/s4/clarity/configuration/workflow.py
+++ b/s4/clarity/configuration/workflow.py
@@ -1,5 +1,6 @@
 # Copyright 2016 Semaphore Solutions, Inc.
 # ---------------------------------------------------------------------------
+from s4.clarity._internal.factory import BatchFlags
 from s4.clarity._internal.props import attribute_property
 from s4.clarity import ClarityElement, lazy_property
 from .stage import Stage
@@ -9,6 +10,7 @@ from s4.clarity.routing import Router
 class Workflow(ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/workflowconfiguration}workflow"
     BATCH_FLAGS = BatchFlags.QUERY
+    REQUEST_PATH = '/configuration/workflows'
 
     PENDING_STATUS = "PENDING"
     ACTIVE_STATUS = "ACTIVE"

--- a/s4/clarity/container.py
+++ b/s4/clarity/container.py
@@ -1,6 +1,6 @@
 # Copyright 2016 Semaphore Solutions, Inc.
 # ---------------------------------------------------------------------------
-
+from s4.clarity._internal.factory import BatchFlags
 from ._internal import WrappedXml, ClarityElement, FieldsMixin
 from s4.clarity._internal.props import subnode_link, subnode_property, subnode_element
 from s4.clarity import types, lazy_property

--- a/s4/clarity/container.py
+++ b/s4/clarity/container.py
@@ -43,6 +43,7 @@ class ContainerDimension(WrappedXml):
 
 class ContainerType(ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/containertype}container-type"
+    BATCH_FLAGS = BatchFlags.QUERY
 
     is_tube = subnode_property("is-tube", types.BOOLEAN)  # type: bool
     x_dimension = subnode_element(ContainerDimension, "x-dimension")  # type: ContainerDimension
@@ -142,6 +143,7 @@ class ContainerType(ClarityElement):
 
 class Container(FieldsMixin, ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/container}container"
+    BATCH_FLAGS = BatchFlags.BATCH_ALL
     ATTACH_TO_NAME = "Container"
 
     container_type = subnode_link(ContainerType, "type", attributes=('name', 'uri'))

--- a/s4/clarity/file.py
+++ b/s4/clarity/file.py
@@ -1,6 +1,6 @@
 # Copyright 2016 Semaphore Solutions, Inc.
 # ---------------------------------------------------------------------------
-
+from s4.clarity._internal.factory import BatchFlags
 from ._internal import ClarityElement
 
 from six import BytesIO, StringIO, string_types

--- a/s4/clarity/file.py
+++ b/s4/clarity/file.py
@@ -23,6 +23,7 @@ class File(ClarityElement):
     """
 
     UNIVERSAL_TAG = "{http://genologics.com/ri/file}file"
+    BATCH_FLAGS = BatchFlags.BATCH_ALL & ~BatchFlags.BATCH_CREATE
 
     def __init__(self, lims, uri=None, xml_root=None, name=None, limsid=None):
         super(File, self).__init__(lims, uri, xml_root, name, limsid)

--- a/s4/clarity/lab.py
+++ b/s4/clarity/lab.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Semaphore Solutions, Inc.
 # ---------------------------------------------------------------------------
-
+from s4.clarity._internal.factory import BatchFlags
 from ._internal import FieldsMixin, ClarityElement
 
 

--- a/s4/clarity/lab.py
+++ b/s4/clarity/lab.py
@@ -6,4 +6,5 @@ from ._internal import FieldsMixin, ClarityElement
 
 class Lab(FieldsMixin, ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/lab}lab"
+    BATCH_FLAGS = BatchFlags.QUERY
     ATTACH_TO_NAME = "ClientLab"

--- a/s4/clarity/lims.py
+++ b/s4/clarity/lims.py
@@ -94,55 +94,50 @@ class LIMS(object):
         self.factories = {}
 
         # there's no need to make these lazy, we are probably using at least a couple of them
-        self.steps = StepFactory(self, Step, batch_flags=BatchFlags.QUERY)
+        self.steps = StepFactory(self, Step)
 
-        self.processes = ElementFactory(self, Process, batch_flags=BatchFlags.QUERY, request_path='/processes')
+        self.processes = ElementFactory(self, Process, request_path='/processes')
 
-        self.samples = ElementFactory(self, Sample, batch_flags=BatchFlags.BATCH_ALL)
+        self.samples = ElementFactory(self, Sample)
 
-        self.artifacts = ElementFactory(self, Artifact, batch_flags=BatchFlags.BATCH_ALL & ~BatchFlags.BATCH_CREATE)
+        self.artifacts = ElementFactory(self, Artifact)
 
-        self.files = ElementFactory(self, File, batch_flags=BatchFlags.BATCH_ALL & ~BatchFlags.BATCH_CREATE)
+        self.files = ElementFactory(self, File)
 
-        self.containers = ElementFactory(self, Container, batch_flags=BatchFlags.BATCH_ALL)
+        self.containers = ElementFactory(self, Container)
 
-        self.container_types = ElementFactory(self, ContainerType, batch_flags=BatchFlags.QUERY)
+        self.container_types = ElementFactory(self, ContainerType)
 
-        self.projects = ElementFactory(self, Project, batch_flags=BatchFlags.QUERY)
+        self.projects = ElementFactory(self, Project)
 
         self.control_types = ElementFactory(self, ControlType)
 
         self.queues = ElementFactory(self, Queue)
 
-        self.reagent_lots = ElementFactory(self, ReagentLot, batch_flags=BatchFlags.QUERY)
+        self.reagent_lots = ElementFactory(self, ReagentLot)
 
-        self.reagent_kits = ElementFactory(self, ReagentKit, batch_flags=BatchFlags.QUERY)
+        self.reagent_kits = ElementFactory(self, ReagentKit)
 
-        self.reagent_types = ElementFactory(self, ReagentType, batch_flags=BatchFlags.QUERY)
+        self.reagent_types = ElementFactory(self, ReagentType)
 
-        self.researchers = ElementFactory(self, Researcher, batch_flags=BatchFlags.QUERY)
+        self.researchers = ElementFactory(self, Researcher)
 
-        self.labs = ElementFactory(self, Lab, batch_flags=BatchFlags.QUERY)
+        self.labs = ElementFactory(self, Lab)
 
-        self.roles = ElementFactory(self, Role, batch_flags=BatchFlags.QUERY)
+        self.roles = ElementFactory(self, Role)
 
-        self.permissions = ElementFactory(self, Permission, batch_flags=BatchFlags.QUERY)
+        self.permissions = ElementFactory(self, Permission)
 
         # configuration
         from .configuration import Workflow, Protocol, ProcessType, Udf, ProcessTemplate, Automation
 
-        self.workflows = ElementFactory(self, Workflow, batch_flags=BatchFlags.QUERY,
-                                        request_path='/configuration/workflows')
-        self.protocols = ElementFactory(self, Protocol, batch_flags=BatchFlags.QUERY,
-                                        request_path='/configuration/protocols')
-        self.udfs = UdfFactory(self, Udf, batch_flags=BatchFlags.QUERY,
-                               request_path='/configuration/udfs')
-        self.process_types = ElementFactory(self, ProcessType, batch_flags=BatchFlags.QUERY,
-                                            name_attribute="displayname")
-        self.process_templates = ElementFactory(self, ProcessTemplate, batch_flags=BatchFlags.QUERY,
-                                                name_attribute="name")
-        self.automations = ElementFactory(self, Automation, batch_flags=BatchFlags.QUERY,
-                                          name_attribute="name", request_path="/configuration/automations")
+        self.workflows = ElementFactory(self, Workflow, request_path='/configuration/workflows')
+
+        self.protocols = ElementFactory(self, Protocol, request_path='/configuration/protocols')
+        self.udfs = UdfFactory(self, Udf, request_path='/configuration/udfs')
+        self.process_types = ElementFactory(self, ProcessType, name_attribute="displayname")
+        self.process_templates = ElementFactory(self, ProcessTemplate, name_attribute="name")
+        self.automations = ElementFactory(self, Automation, name_attribute="name", request_path="/configuration/automations")
 
         self.stages = ElementFactory(self, Stage)
 

--- a/s4/clarity/lims.py
+++ b/s4/clarity/lims.py
@@ -11,7 +11,6 @@ import urllib3
 # Ensure Python 2 and 3 compatibility
 from six import BytesIO, b
 
-from s4.clarity._internal.factory import BatchFlags
 from s4.clarity._internal.stepfactory import StepFactory, ElementFactory
 from s4.clarity._internal.udffactory import UdfFactory
 from s4.clarity._internal.lazy_property import lazy_property
@@ -91,12 +90,13 @@ class LIMS(object):
         from .configuration.stage import Stage
         from .lab import Lab
 
+        # Initialise the list of factories. The element factories will
+        # add themselves to this dictionary when they are created
         self.factories = {}
 
-        # there's no need to make these lazy, we are probably using at least a couple of them
         self.steps = StepFactory(self, Step)
 
-        self.processes = ElementFactory(self, Process, request_path='/processes')
+        self.processes = ElementFactory(self, Process)
 
         self.samples = ElementFactory(self, Sample)
 
@@ -131,13 +131,17 @@ class LIMS(object):
         # configuration
         from .configuration import Workflow, Protocol, ProcessType, Udf, ProcessTemplate, Automation
 
-        self.workflows = ElementFactory(self, Workflow, request_path='/configuration/workflows')
+        self.workflows = ElementFactory(self, Workflow)
 
-        self.protocols = ElementFactory(self, Protocol, request_path='/configuration/protocols')
-        self.udfs = UdfFactory(self, Udf, request_path='/configuration/udfs')
-        self.process_types = ElementFactory(self, ProcessType, name_attribute="displayname")
-        self.process_templates = ElementFactory(self, ProcessTemplate, name_attribute="name")
-        self.automations = ElementFactory(self, Automation, name_attribute="name", request_path="/configuration/automations")
+        self.protocols = ElementFactory(self, Protocol)
+
+        self.udfs = UdfFactory(self, Udf)
+
+        self.process_types = ElementFactory(self, ProcessType)
+
+        self.process_templates = ElementFactory(self, ProcessTemplate)
+
+        self.automations = ElementFactory(self, Automation)
 
         self.stages = ElementFactory(self, Stage)
 

--- a/s4/clarity/permission.py
+++ b/s4/clarity/permission.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Semaphore Solutions, Inc.
 # ---------------------------------------------------------------------------
-
+from s4.clarity._internal.factory import BatchFlags
 from ._internal import ClarityElement
 from ._internal.props import subnode_property
 

--- a/s4/clarity/permission.py
+++ b/s4/clarity/permission.py
@@ -7,6 +7,7 @@ from ._internal.props import subnode_property
 
 class Permission(ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/permission}permission"
+    BATCH_FLAGS = BatchFlags.QUERY
 
     description = subnode_property("description")
     action = subnode_property("action")

--- a/s4/clarity/process.py
+++ b/s4/clarity/process.py
@@ -18,6 +18,7 @@ class Process(IOMapsMixin, FieldsMixin, ClarityElement):
     :ivar LIMS lims:
     """
     UNIVERSAL_TAG = "{http://genologics.com/ri/process}process"
+    BATCH_FLAGS = BatchFlags.QUERY
     ATTACH_TO_CATEGORY = "ProcessType"
     IOMAPS_XPATH = "input-output-map"
     IOMAPS_OUTPUT_TYPE_ATTRIBUTE = "output-type"

--- a/s4/clarity/process.py
+++ b/s4/clarity/process.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Semaphore Solutions, Inc.
 # ---------------------------------------------------------------------------
-
+from s4.clarity._internal.factory import BatchFlags
 from ._internal import ClarityElement, FieldsMixin
 from .iomaps import IOMapsMixin
 from ._internal.props import subnode_link
@@ -19,6 +19,7 @@ class Process(IOMapsMixin, FieldsMixin, ClarityElement):
     """
     UNIVERSAL_TAG = "{http://genologics.com/ri/process}process"
     BATCH_FLAGS = BatchFlags.QUERY
+    REQUEST_PATH = '/processes'
     ATTACH_TO_CATEGORY = "ProcessType"
     IOMAPS_XPATH = "input-output-map"
     IOMAPS_OUTPUT_TYPE_ATTRIBUTE = "output-type"

--- a/s4/clarity/project.py
+++ b/s4/clarity/project.py
@@ -1,6 +1,6 @@
 # Copyright 2016 Semaphore Solutions, Inc.
 # ---------------------------------------------------------------------------
-
+from s4.clarity._internal.factory import BatchFlags
 from ._internal import ClarityElement, FieldsMixin
 from s4.clarity._internal.props import subnode_property, subnode_link
 from s4.clarity.researcher import Researcher

--- a/s4/clarity/project.py
+++ b/s4/clarity/project.py
@@ -9,6 +9,8 @@ from s4.clarity import types
 
 class Project(FieldsMixin, ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/project}project"
+    BATCH_FLAGS = BatchFlags.QUERY
+
     ATTACH_TO_NAME = "Project"
 
     open_date = subnode_property("open-date", types.DATE)

--- a/s4/clarity/reagent_kit.py
+++ b/s4/clarity/reagent_kit.py
@@ -8,6 +8,7 @@ from s4.clarity import types, lazy_property
 
 class ReagentKit(ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/reagentkit}reagent-kit"
+    BATCH_FLAGS = BatchFlags.QUERY
 
     name = subnode_property("name")
     supplier = subnode_property("lot-supplier")

--- a/s4/clarity/reagent_kit.py
+++ b/s4/clarity/reagent_kit.py
@@ -1,6 +1,6 @@
 # Copyright 2016 Semaphore Solutions, Inc.
 # ---------------------------------------------------------------------------
-
+from s4.clarity._internal.factory import BatchFlags
 from ._internal import ClarityElement
 from ._internal.props import subnode_property
 from s4.clarity import types, lazy_property

--- a/s4/clarity/reagent_lot.py
+++ b/s4/clarity/reagent_lot.py
@@ -9,6 +9,7 @@ from s4.clarity import types
 
 class ReagentLot(ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/reagentlot}reagent-lot"
+    BATCH_FLAGS = BatchFlags.QUERY
 
     reagent_kit = subnode_link(ReagentKit, "reagent-kit", attributes=('uri',))
 

--- a/s4/clarity/reagent_lot.py
+++ b/s4/clarity/reagent_lot.py
@@ -1,6 +1,6 @@
 # Copyright 2016 Semaphore Solutions, Inc.
 # ---------------------------------------------------------------------------
-
+from s4.clarity._internal.factory import BatchFlags
 from ._internal import ClarityElement
 from ._internal.props import subnode_property, subnode_link
 from .reagent_kit import ReagentKit

--- a/s4/clarity/reagent_type.py
+++ b/s4/clarity/reagent_type.py
@@ -2,6 +2,8 @@
 # ---------------------------------------------------------------------------
 
 from future.utils import python_2_unicode_compatible
+
+from s4.clarity._internal.factory import BatchFlags
 from ._internal import ClarityElement
 from ._internal.props import subnode_property, subnode_property_literal_dict
 from s4.clarity import ETree

--- a/s4/clarity/reagent_type.py
+++ b/s4/clarity/reagent_type.py
@@ -9,6 +9,7 @@ from s4.clarity import ETree
 
 class ReagentType(ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/reagenttype}reagent-type"
+    BATCH_FLAGS = BatchFlags.QUERY
 
     @python_2_unicode_compatible
     def __str__(self):

--- a/s4/clarity/researcher.py
+++ b/s4/clarity/researcher.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Semaphore Solutions, Inc.
 # ---------------------------------------------------------------------------
-
+from s4.clarity._internal.factory import BatchFlags
 from ._internal import FieldsMixin, ClarityElement
 from s4.clarity.role import Role
 from ._internal.props import subnode_property, subnode_links, subnode_link

--- a/s4/clarity/researcher.py
+++ b/s4/clarity/researcher.py
@@ -10,6 +10,7 @@ from s4.clarity.lab import Lab
 
 class Researcher(FieldsMixin, ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/researcher}researcher"
+    BATCH_FLAGS = BatchFlags.QUERY
     ATTACH_TO_NAME = "ClientResearcher"
 
     first_name = subnode_property("first-name")

--- a/s4/clarity/role.py
+++ b/s4/clarity/role.py
@@ -9,6 +9,7 @@ from s4.clarity import lazy_property
 
 class Role(ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/role}role"
+    BATCH_FLAGS = BatchFlags.QUERY
 
     # Not using subnode_links for this property, as it requires a Researcher import that creates a circular dependency
     @lazy_property

--- a/s4/clarity/role.py
+++ b/s4/clarity/role.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Semaphore Solutions, Inc.
 # ---------------------------------------------------------------------------
-
+from s4.clarity._internal.factory import BatchFlags
 from ._internal import ClarityElement
 from s4.clarity._internal.props import subnode_links
 from s4.clarity.permission import Permission

--- a/s4/clarity/sample.py
+++ b/s4/clarity/sample.py
@@ -3,6 +3,7 @@
 
 import logging
 
+from s4.clarity._internal.factory import BatchFlags
 from ._internal import FieldsMixin, ClarityElement
 from ._internal.props import subnode_property, subnode_link
 from s4.clarity.project import Project

--- a/s4/clarity/sample.py
+++ b/s4/clarity/sample.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 
 class Sample(FieldsMixin, ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/sample}sample"
+    BATCH_FLAGS = BatchFlags.BATCH_ALL
     # special tag used for creation posts
     CREATION_TAG = "{http://genologics.com/ri/sample}samplecreation"
     ATTACH_TO_NAME = "Sample"

--- a/s4/clarity/step.py
+++ b/s4/clarity/step.py
@@ -5,6 +5,7 @@ import logging
 import time
 import re
 
+from s4.clarity._internal.factory import BatchFlags
 from s4.clarity.artifact import Artifact
 from s4.clarity.researcher import Researcher
 from s4.clarity import lazy_property

--- a/s4/clarity/step.py
+++ b/s4/clarity/step.py
@@ -36,6 +36,7 @@ PROGRAM_STATUS_QUEUED = "QUEUED"
 
 class Step(ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/step}step"
+    BATCH_FLAGS = BatchFlags.QUERY
 
     date_started = subnode_property("date-started", types.DATETIME)
     date_completed = subnode_property("date-completed", types.DATETIME)

--- a/s4/clarity/test/s4/clarity/_internal/test_element_factory.py
+++ b/s4/clarity/test/s4/clarity/_internal/test_element_factory.py
@@ -1,0 +1,128 @@
+
+from unittest import TestCase
+from s4.clarity._internal.factory import BatchFlags, ElementFactory
+
+
+class LocalLIMS(object):
+    """
+    We need a super small lims class to test the batch flag functions.
+    """
+    def __init__(self):
+        self.root_uri = "http://localhost/api/v2"
+        self.factories = {}
+
+
+class TestElementFactory(TestCase):
+
+    def test_are_default_batch_tags_correct_on_factory(self):
+
+        class TestElement(object):
+            """
+            Note the lack of batch flag constants
+            """
+            pass
+
+        # We default to false for everything.
+        test_factory = ElementFactory(LocalLIMS(), TestElement)
+        self.assertFalse(test_factory.can_batch_create())
+        self.assertFalse(test_factory.can_batch_get())
+        self.assertFalse(test_factory.can_batch_update())
+        self.assertFalse(test_factory.can_query())
+
+    def test_are_none_batch_tags_correct_on_factory(self):
+
+        class TestElement(object):
+            BATCH_FLAGS = BatchFlags.NONE
+
+        # We default to false for everything.
+        test_factory = ElementFactory(LocalLIMS(), TestElement)
+        self.assertFalse(test_factory.can_batch_create())
+        self.assertFalse(test_factory.can_batch_get())
+        self.assertFalse(test_factory.can_batch_update())
+        self.assertFalse(test_factory.can_query())
+
+    def test_are_batch_all_tags_read_by_factory(self):
+
+        class TestElement(object):
+            BATCH_FLAGS = BatchFlags.BATCH_ALL
+
+        test_factory = ElementFactory(LocalLIMS(), TestElement)
+        self.assertTrue(test_factory.can_batch_create())
+        self.assertTrue(test_factory.can_batch_get())
+        self.assertTrue(test_factory.can_batch_update())
+        self.assertTrue(test_factory.can_query())
+
+    def test_are_create_batch_tags_read_by_factory(self):
+
+        class TestElement(object):
+            BATCH_FLAGS = BatchFlags.BATCH_CREATE
+
+        test_factory = ElementFactory(LocalLIMS(), TestElement)
+        self.assertTrue(test_factory.can_batch_create())
+        self.assertFalse(test_factory.can_batch_get())
+        self.assertFalse(test_factory.can_batch_update())
+        self.assertFalse(test_factory.can_query())
+
+    def test_are_get_batch_tags_read_by_factory(self):
+
+        class TestElement(object):
+            BATCH_FLAGS = BatchFlags.BATCH_GET
+
+        test_factory = ElementFactory(LocalLIMS(), TestElement)
+        self.assertFalse(test_factory.can_batch_create())
+        self.assertTrue(test_factory.can_batch_get())
+        self.assertFalse(test_factory.can_batch_update())
+        self.assertFalse(test_factory.can_query())
+
+    def test_are_batch_update_tags_read_by_factory(self):
+
+        class TestElement(object):
+            BATCH_FLAGS = BatchFlags.BATCH_UPDATE
+
+        test_factory = ElementFactory(LocalLIMS(), TestElement)
+        self.assertFalse(test_factory.can_batch_create())
+        self.assertFalse(test_factory.can_batch_get())
+        self.assertTrue(test_factory.can_batch_update())
+        self.assertFalse(test_factory.can_query())
+
+    def test_are_query_tags_read_by_factory(self):
+
+        class TestElement(object):
+            BATCH_FLAGS = BatchFlags.QUERY
+
+        test_factory = ElementFactory(LocalLIMS(), TestElement)
+        self.assertFalse(test_factory.can_batch_create())
+        self.assertFalse(test_factory.can_batch_get())
+        self.assertFalse(test_factory.can_batch_update())
+        self.assertTrue(test_factory.can_query())
+
+    def test_name_attr_default(self):
+
+        class TestElement(object):
+            pass
+
+        # name is the default name attribute
+        test_factory = ElementFactory(LocalLIMS(), TestElement)
+        self.assertEqual(test_factory.name_attribute, "name")
+
+    def test_name_attr_set(self):
+        class TestElement(object):
+            NAME_ATTRIBUTE = "test_name"
+
+        test_factory = ElementFactory(LocalLIMS(), TestElement)
+        self.assertEqual(test_factory.name_attribute, "test_name")
+
+    def test_request_path(self):
+        class TestElement(object):
+            REQUEST_PATH = "test/path"
+
+        test_factory = ElementFactory(LocalLIMS(), TestElement)
+        self.assertTrue(test_factory.uri.endswith("test/path"))
+
+    def test_request_path_default(self):
+        class TestElement(object):
+            pass
+
+        # Look for the pluralised element name
+        test_factory = ElementFactory(LocalLIMS(), TestElement)
+        self.assertTrue(test_factory.uri.endswith("testelements"))


### PR DESCRIPTION
Moving the Batch Flags, Request Path and Name Attribute values out of the Element Factory initializers and into class constants on the actual element objects.  Added some expanded comments and unit tests to verify expected behaviour.

Multiple `can_batch_X()` methods on the ElementFactory have the values cast to bool as that is what they report to return, but were returning int values.