### PR TITLE
Clearing Selected Containers on Post Tube to Tube

### DIFF
--- a/s4/clarity/container.py
+++ b/s4/clarity/container.py
@@ -178,4 +178,7 @@ class Container(FieldsMixin, ClarityElement):
 
         :rtype: Artifact or None
         """
-        return self.placements[well]
+        try:
+            return self.placements[well]
+        except KeyError:
+            raise KeyError("Container '%s' has no artifact at '%s'." % (self.name, well))

--- a/s4/clarity/steputils/step_runner.py
+++ b/s4/clarity/steputils/step_runner.py
@@ -310,6 +310,7 @@ class StepRunner:
             raise Exception("The post_tube_to_tube method can only be called with tube-like containers.")
 
         self.step.placements.clear_placements()
+        self.step.placements.clear_selected_containers()
 
         new_containers = self.lims.containers.batch_create(
             [self.lims.containers.new(name=output.limsid, container_type=container_type)


### PR DESCRIPTION
With the original on the fly container still in the selected container,
it will not be deleted when posting tube to tube.