### PR TITLE
Prefetch all samples for a pool not just one

### DIFF
--- a/s4/clarity/scripts/stepepp.py
+++ b/s4/clarity/scripts/stepepp.py
@@ -134,7 +134,7 @@ class StepEPP(GenericScript):
         if StepEPP.PREFETCH_SAMPLES in categories:
             # use the artifacts that we prefetched to find samples.
             # we use a set because we may have both inputs and outputs in the artifacts_to_fetch list.
-            samples = list(set([x.sample for x in artifacts]))
+            samples = list({sample for a in artifacts for sample in a.samples})
             self.lims.samples.batch_fetch(samples)
             return samples + artifacts
 

--- a/s4/clarity/scripts/test/test_stepepp.py
+++ b/s4/clarity/scripts/test/test_stepepp.py
@@ -10,12 +10,10 @@ from s4.clarity.artifact import Artifact
 from s4.clarity.scripts.stepepp import StepEPP
 
 
+@patch('s4.clarity.LIMS')
 class TestStepEPP(TestCase):
 
-    @patch("s4.clarity.LIMS")
     def test_prefetch(self, mock_lims):
-        stepepp = SomeStepEPP(FakeOptions)
-
         inputs = [Mock(Artifact, name='Input A'),
             Mock(Artifact, name='Input B'),
             Mock(Artifact, name='Input C')]
@@ -26,9 +24,21 @@ class TestStepEPP(TestCase):
 
         samples = ["sample0", "sample1", "sample2"]
         for i in range(len(inputs)):
-            inputs[i].sample = samples[i]
-            outputs[i].sample = samples[i]
+            inputs[i].samples = [samples[i]]
+            outputs[i].samples = [samples[i]]
 
+        self._execute_prefetch_tests(inputs, outputs, samples)
+
+    def test_prefetch_with_pools(self, mock_lims):
+        inputs = [Mock(Artifact, name='Input Pool A')]
+        outputs = [Mock(Artifact, name='Output Pool A')]
+        samples = ['sample0', 'sample1', 'sample2']
+        inputs[0].samples = samples
+        outputs[0].samples = samples
+        self._execute_prefetch_tests(inputs, outputs, samples)
+
+    def _execute_prefetch_tests(self, inputs, outputs, samples):
+        stepepp = SomeStepEPP(FakeOptions)
         stepepp.step = MagicMock(Step)
         type(stepepp.step.details).inputs = PropertyMock(return_value=inputs)
         type(stepepp.step.details).outputs = PropertyMock(return_value=outputs)


### PR DESCRIPTION
Fixes a small bug in the `prefetch` function. Currently, the artifact's `sample` property (rather than its `samples` property) is used when generating the list of samples to prefetch, so if the artifact is a pool, only one of its samples is retrieved by the function.