### PR TITLE
Added 'link_node' argument to ClarityElement

### DIFF
--- a/s4/clarity/_internal/element.py
+++ b/s4/clarity/_internal/element.py
@@ -125,11 +125,12 @@ class ClarityElement(WrappedXml):
 
     UNIVERSAL_TAG = None
 
-    def __init__(self, lims, uri=None, xml_root=None, name=None, limsid=None):
+    def __init__(self, lims, uri=None, xml_root=None, name=None, limsid=None, link_node=None):
         super(ClarityElement, self).__init__(lims, None)
         self.uri = uri
         self._name = name
         self._limsid = limsid
+        self._link_node = link_node
 
         # use property setter to ensure post-set steps are correctly followed
         self.xml_root = xml_root

--- a/s4/clarity/_internal/factory.py
+++ b/s4/clarity/_internal/factory.py
@@ -156,7 +156,8 @@ class ElementFactory(object):
 
         if xml_node is None:
             return None
-        obj = self.get(xml_node.get("uri"), name=xml_node.get("name"), limsid=xml_node.get("limsid"))
+        obj = self.get(xml_node.get("uri"), name=xml_node.get("name"), limsid=xml_node.get("limsid"),
+            link_node=xml_node)
         return obj
 
     def from_link_nodes(self, xml_nodes):
@@ -201,12 +202,12 @@ class ElementFactory(object):
 
         return matches[0]
 
-    def get(self, uri, force_full_get=False, name=None, limsid=None):
-        # type: (str, bool, str, str) -> ClarityElement
+    def get(self, uri, force_full_get=False, name=None, limsid=None, link_node=None):
+        # type: (str, bool, str, str, ETree.Element) -> ClarityElement
         """
         Returns the cached ClarityElement described by the provide uri. If the
         element does not exist a new cache entry will be created with the provided
-        name and limsid.
+        name, limsid, and link_node.
         If force_full_get is true, and the object is not fully retrieved it will be refreshed.
         """
 
@@ -215,7 +216,7 @@ class ElementFactory(object):
         if uri in self._cache:
             obj = self._cache[uri]
         else:
-            obj = self.element_class(self.lims, uri=uri, name=name, limsid=limsid)
+            obj = self.element_class(self.lims, uri=uri, name=name, limsid=limsid, link_node=link_node)
             self._cache[uri] = obj
 
         if force_full_get and not obj.is_fully_retrieved():

--- a/s4/clarity/artifact.py
+++ b/s4/clarity/artifact.py
@@ -43,9 +43,6 @@ class Artifact(FieldsMixin, ClarityElement):
     reagent_labels = subnode_element_list(ReagentLabel, ".", "reagent-label", readonly=True)
     parent_process = subnode_link(Process, 'parent-process')
 
-    def __init__(self, lims,  uri=None, xml_root=None, name=None, limsid=None):
-        super(Artifact, self).__init__(lims, uri, xml_root, name, limsid)
-
     @property
     def parent_step(self):
         """:type: Step"""

--- a/s4/clarity/configuration/workflow.py
+++ b/s4/clarity/configuration/workflow.py
@@ -13,7 +13,7 @@ class Workflow(ClarityElement):
     ACTIVE_STATUS = "ACTIVE"
     ARCHIVED_STATUS = "ARCHIVED"
 
-    status = attribute_property("status")
+    status = attribute_property("status", may_use_link_node=True)
 
     @property
     def is_active(self):

--- a/s4/clarity/file.py
+++ b/s4/clarity/file.py
@@ -24,8 +24,8 @@ class File(ClarityElement):
 
     UNIVERSAL_TAG = "{http://genologics.com/ri/file}file"
 
-    def __init__(self, lims, uri=None, xml_root=None, name=None, limsid=None):
-        super(File, self).__init__(lims, uri, xml_root, name, limsid)
+    def __init__(self, lims, uri=None, xml_root=None, name=None, limsid=None, link_node=None):
+        super(File, self).__init__(lims, uri, xml_root, name, limsid, link_node)
         self._data = None
         self._dirty = False
         self.content_type = 'text/plain'


### PR DESCRIPTION
Added 'link_node' argument to ClarityElement, stores the ETree.Element used by ElementFactory.from_link_node, and attribute_property knows how to use it to avoid extra API calls. Currently only used by Workflow.status.

NOTE: this is possibly very useful for UPMC, whose WorkflowRouting class is called at the start of... every EPP?.. many EPPs?.. and which attempts to filter all workflows in `lims.workflows.all(prefetch=False)` based on their `status`. Before this PR, accessing `Workflow.status` resulted in an API call for that workflow. And UPMC has 78 workflows!.. But after this PR, accessing `Workflow.status` doesn't require an API call if the workflow was generated by `lims.workflows.all(prefetch=False)`.