### PR TITLE
Fix typo in the control type universal tag

### DIFF
--- a/s4/clarity/control_type.py
+++ b/s4/clarity/control_type.py
@@ -7,7 +7,7 @@ from s4.clarity import types
 
 
 class ControlType(ClarityElement):
-    UNIVERSAL_TAG = "{http://genologics.com/ri/controltype}controltype"
+    UNIVERSAL_TAG = "{http://genologics.com/ri/controltype}control-type"
 
     supplier = subnode_property("supplier")
     catalogue_number = subnode_property("catalogue-number")


### PR DESCRIPTION
Fixes a typo in the UNIVERSAL_TAG constant of the ControlType element.

This makes it possible to add new controls to Clarity, i.e.
```
test_control = self.lims.control_types.new()
test_control.xml_root.set("name", "Test Control")
self.lims.control_types.add(test_control)
```

Without this fix in place, the above code raises a somewhat cryptic exception: `s4.clarity.ClarityException: cvc-elt.1: Cannot find the declaration of element 'ns0:controltype'.`. But with the fix in place, the control will be successfully created.