### PR TITLE
Adds a files property to the Project class

### DIFF
--- a/s4/clarity/_internal/props.py
+++ b/s4/clarity/_internal/props.py
@@ -180,7 +180,7 @@ class subnode_link(_clarity_property):
     root.sample == <Sample limsid='1234'>
     """
 
-    def __init__(self, element_type, property_name, readonly=False, attributes=('limsid','uri')):
+    def __init__(self, element_type, property_name, readonly=False, attributes=('limsid', 'uri')):
         """
         :type element_type: Type[s4.clarity._internal.element.ClarityElement]
         :type property_name: str

--- a/s4/clarity/project.py
+++ b/s4/clarity/project.py
@@ -15,3 +15,9 @@ class Project(FieldsMixin, ClarityElement):
     close_date = subnode_property("close-date", types.DATE)
     invoice_date = subnode_property("invoice-date", types.DATE)
     researcher = subnode_link(Researcher, "researcher", attributes=('uri',))  # type: Researcher
+
+    @property
+    def files(self):
+        """:type: list[File]"""
+        return self.lims.files.from_link_nodes(self.xml_findall(File.UNIVERSAL_TAG))
+

--- a/s4/clarity/project.py
+++ b/s4/clarity/project.py
@@ -4,6 +4,7 @@
 from ._internal import ClarityElement, FieldsMixin
 from s4.clarity._internal.props import subnode_property, subnode_link
 from s4.clarity.researcher import Researcher
+from s4.clarity.file import File
 from s4.clarity import types
 
 

--- a/s4/clarity/project.py
+++ b/s4/clarity/project.py
@@ -2,13 +2,17 @@
 # ---------------------------------------------------------------------------
 
 from ._internal import ClarityElement, FieldsMixin
-from s4.clarity._internal.props import subnode_property, subnode_link
+from s4.clarity._internal.props import subnode_property, subnode_link, subnode_links
 from s4.clarity.researcher import Researcher
 from s4.clarity.file import File
 from s4.clarity import types
 
 
 class Project(FieldsMixin, ClarityElement):
+    """
+    Reference: https://d10e8rzir0haj8.cloudfront.net/5.3/rest.version.projects.html
+    """
+
     UNIVERSAL_TAG = "{http://genologics.com/ri/project}project"
     ATTACH_TO_NAME = "Project"
 
@@ -16,9 +20,4 @@ class Project(FieldsMixin, ClarityElement):
     close_date = subnode_property("close-date", types.DATE)
     invoice_date = subnode_property("invoice-date", types.DATE)
     researcher = subnode_link(Researcher, "researcher", attributes=('uri',))  # type: Researcher
-
-    @property
-    def files(self):
-        """:type: list[File]"""
-        return self.lims.files.from_link_nodes(self.xml_findall(File.UNIVERSAL_TAG))
-
+    files = subnode_links(File, File.UNIVERSAL_TAG)


### PR DESCRIPTION
Context:
My use of the files section on the Clarity project is very limited. However, some recent Avelino work drew my attention to an aspect of the Clarity API re: `project`: There are `file` sub-nodes in the `project` xml, not handled by the s4-clarity library.

PR Description: 
+ Adds a new `files` property in the `Project` class

Considerations:
+ Looking at `s4/clarity/test/`, I could write a test for the `Project` class? 
+ Comparing `tree` for the `test` directory w/ `s4-clarity`, I don't know if the organization of files is intentional? but I could rearrange them to match? I suspect this is a useless endeavour i.e. more aesthetics than functional?