### PR TITLE
Support Instruments API endpoint

### DIFF
--- a/docs/api/clarity.rst
+++ b/docs/api/clarity.rst
@@ -111,6 +111,13 @@ File
     :members:
     :show-inheritance:
 
+Instrument
+--------
+
+.. autoclass:: s4.clarity.instrument.Instrument
+    :members:
+    :show-inheritance:
+
 IO Map
 ------
 

--- a/s4/clarity/configuration/protocol.py
+++ b/s4/clarity/configuration/protocol.py
@@ -129,7 +129,7 @@ class StepConfiguration(ClarityElement):
         :type: List[str]
         """
         instrument_type_nodes = self.xml_findall("./permitted-instrument-types/instrument-type")
-        return list({node.text for node in instrument_type_nodes})
+        return [node.text for node in instrument_type_nodes]
 
     @lazy_property
     def queue(self):

--- a/s4/clarity/configuration/protocol.py
+++ b/s4/clarity/configuration/protocol.py
@@ -124,6 +124,14 @@ class StepConfiguration(ClarityElement):
         return [ControlType(self.lims, p.get("uri")) for p in control_types]
 
     @lazy_property
+    def permitted_instrument_types(self):
+        """
+        :type: List[str]
+        """
+        instrument_type_nodes = self.xml_findall("./permitted-instrument-types/instrument-type")
+        return list({node.text for node in instrument_type_nodes})
+
+    @lazy_property
     def queue(self):
         """
         :type: Queue

--- a/s4/clarity/instrument.py
+++ b/s4/clarity/instrument.py
@@ -1,0 +1,33 @@
+# Copyright 2021 Semaphore Solutions, Inc.
+# ---------------------------------------------------------------------------
+
+from ._internal import ClarityElement
+from ._internal.props import subnode_property
+from s4.clarity import types, lazy_property
+
+
+class Instrument(ClarityElement):
+    """
+    Reference: https://d10e8rzir0haj8.cloudfront.net/5.3/rest.version.instruments.html
+    Note: limsid attribute in xml root e.g. "55-x" does not have use in API, using uri id for Instrument object limsid
+        <inst:instrument xmlns:inst="http://genologics.com/ri/instrument" limsid="55-x" uri="https://clarityhost/api/v2/instruments/6">
+    """
+
+    UNIVERSAL_TAG = "{http://genologics.com/ri/instrument}instrument"
+
+    name = subnode_property("name")
+    instrument_type = subnode_property("type")
+    serial_number = subnode_property("serial-number")
+    expiry_date = subnode_property("expiry-date", types.DATE)
+    archived = subnode_property("archived", types.BOOLEAN)
+
+    @lazy_property
+    def related_instruments(self):
+        """
+        :return: List of instruments of the same instrument type
+        :rtype: List[Instrument]
+        Note: Clarity 5.2+ does NOT permit duplicate instrument type entries via UX/UI
+        """
+        instruments = self.lims.instruments.all()
+        return [instrument for instrument in instruments
+                if instrument.instrument_type == self.instrument_type]

--- a/s4/clarity/instrument.py
+++ b/s4/clarity/instrument.py
@@ -9,9 +9,9 @@ from s4.clarity import types, lazy_property
 class Instrument(ClarityElement):
     """
     Reference: https://d10e8rzir0haj8.cloudfront.net/5.3/rest.version.instruments.html
-    Note: xml root limsid attribute e.g. "55-6" does not have use in API.
-        Instead, use uri id for Instrument object limsid
+    Note: See example xml_root below --
         <inst:instrument xmlns:inst="http://genologics.com/ri/instrument" limsid="55-6" uri="https://clarityhost/api/v2/instruments/6">
+        We use uri id for Instrument object limsid i.e. "6" instead of "55-6"
 
     Cautionary Notes:
     In most cases, a Step UDF or Reagent Kit/Reagent Lot is a better option to track instrument use in the LIMS.

--- a/s4/clarity/instrument.py
+++ b/s4/clarity/instrument.py
@@ -9,8 +9,17 @@ from s4.clarity import types, lazy_property
 class Instrument(ClarityElement):
     """
     Reference: https://d10e8rzir0haj8.cloudfront.net/5.3/rest.version.instruments.html
-    Note: limsid attribute in xml root e.g. "55-x" does not have use in API, using uri id for Instrument object limsid
-        <inst:instrument xmlns:inst="http://genologics.com/ri/instrument" limsid="55-x" uri="https://clarityhost/api/v2/instruments/6">
+    Note: xml root limsid attribute e.g. "55-6" does not have use in API.
+        Instead, use uri id for Instrument object limsid
+        <inst:instrument xmlns:inst="http://genologics.com/ri/instrument" limsid="55-6" uri="https://clarityhost/api/v2/instruments/6">
+
+    Cautionary Notes:
+    In most cases, a Step UDF or Reagent Kit/Reagent Lot is a better option to track instrument use in the LIMS.
+    Consider --
+    1. Instrument API endpoint only permits GET
+    2. You may configure multiple Instruments to step. However, you can only assign 1 Instrument per step
+    3. If Instrument is configured to step, Step UDFs CAN NOT be set via the API, until the Instrument field is set via UX/UI
+    4. Instruments are not part of the ETL that supports Illumina’s Reporting Module
     """
 
     UNIVERSAL_TAG = "{http://genologics.com/ri/instrument}instrument"
@@ -25,7 +34,7 @@ class Instrument(ClarityElement):
     def related_instruments(self):
         """
         :return: List of instruments of the same instrument type
-        :rtype: List[Instrument]
+        :type: List[Instrument]
         Note: Clarity 5.2+ does NOT permit duplicate instrument type entries via UX/UI
         """
         instruments = self.lims.instruments.all()

--- a/s4/clarity/instrument.py
+++ b/s4/clarity/instrument.py
@@ -18,8 +18,9 @@ class Instrument(ClarityElement):
     Consider --
     1. Instrument API endpoint only permits GET
     2. You may configure multiple Instruments to step. However, you can only assign 1 Instrument per step
-    3. If Instrument is configured to step, Step UDFs CAN NOT be set via the API, until the Instrument field is set via UX/UI
-    4. Instruments are not part of the ETL that supports Illumina’s Reporting Module
+    3. If Instrument is configured to step, Step UDFs CAN NOT be set via the API,
+        until the Instrument field is set via UX/UI
+    4. Instruments are not part of the ETL that supports the Illumina Reporting Module
     """
 
     UNIVERSAL_TAG = "{http://genologics.com/ri/instrument}instrument"

--- a/s4/clarity/instrument.py
+++ b/s4/clarity/instrument.py
@@ -36,7 +36,6 @@ class Instrument(ClarityElement):
         """
         :return: List of instruments of the same instrument type
         :type: List[Instrument]
-        Note: Clarity 5.2+ does NOT permit duplicate instrument type entries via UX/UI
         """
         instruments = self.lims.instruments.all()
         return [instrument for instrument in instruments

--- a/s4/clarity/lims.py
+++ b/s4/clarity/lims.py
@@ -30,12 +30,14 @@ class LIMS(object):
     :param bool dry_run: If true, no destructive requests will be made to the Clarity API. Default false.
     :param bool insecure: Disables SSL validation. Default false.
     :param int timeout: Number of seconds to wait for connections and for reads from the Clarity API. Default None, which is no timeout.
+
     :ivar ElementFactory steps: Factory for :class:`s4.clarity.step.Step`
     :ivar ElementFactory samples: Factory for :class:`s4.clarity.sample.Sample`
     :ivar ElementFactory artifacts: Factory for :class:`s4.clarity.artifact.Artifact`
     :ivar ElementFactory files: Factory for :class:`s4.clarity.file.File`
     :ivar ElementFactory containers: Factory for :class:`s4.clarity.container.Container`
     :ivar ElementFactory projects: Factory for :class:`s4.clarity.project.Project`
+    :ivar ElementFactory instruments: Factory for :class:`s4.clarity.instrument.Instrument`
     :ivar ElementFactory workflows: Factory for :class:`s4.clarity.configuration.workflow.Workflow`
     :ivar ElementFactory protocols: Factory for :class:`s4.clarity.configuration.protocol.Protocol`
     :ivar ElementFactory process_types: Factory for :class:`s4.clarity.configuration.process_type.ProcessType`
@@ -87,6 +89,7 @@ class LIMS(object):
         from .reagent_kit import ReagentKit
         from .reagent_lot import ReagentLot
         from .reagent_type import ReagentType
+        from .instrument import Instrument
         from .researcher import Researcher
         from .role import Role
         from .permission import Permission
@@ -116,6 +119,8 @@ class LIMS(object):
         self.control_types = ElementFactory(self, ControlType)
 
         self.queues = ElementFactory(self, Queue)
+
+        self.instruments = ElementFactory(self, Instrument, batch_flags=BatchFlags.QUERY)
 
         self.reagent_lots = ElementFactory(self, ReagentLot, batch_flags=BatchFlags.QUERY)
 

--- a/s4/clarity/step.py
+++ b/s4/clarity/step.py
@@ -11,6 +11,7 @@ from s4.clarity import lazy_property
 
 from . import ETree, ClarityException
 from . import types
+from .instrument import Instrument
 from .reagent_lot import ReagentLot
 from .container import Container
 from .iomaps import IOMapsMixin
@@ -415,6 +416,16 @@ class StepDetails(IOMapsMixin, FieldsMixin, ClarityElement):
     def _get_iomaps_shared_result_file_type(self):
         return "ResultFile"
 
+    @lazy_property
+    def instrument_used(self):
+        """
+        :type: Instrument
+        """
+        instrument_node = self.xml_find("./instrument")
+        if instrument_node is None:
+            return None
+        return Instrument(lims=self.lims, uri=instrument_node.get("uri"))
+
 
 class StepPools(ClarityElement):
     UNIVERSAL_TAG = "{http://genologics.com/ri/step}pools"
@@ -732,4 +743,3 @@ class OutputReagent(WrappedXml):
             node = ETree.SubElement(self.xml_root, "reagent-label")
 
         node.set("name", value)
-

--- a/s4/clarity/step.py
+++ b/s4/clarity/step.py
@@ -376,6 +376,7 @@ class StepDetails(IOMapsMixin, FieldsMixin, ClarityElement):
     :ivar str|None uri:
     :ivar LIMS lims:
     """
+
     UNIVERSAL_TAG = "{http://genologics.com/ri/step}details"
     FIELDS_XPATH = "./fields"
     ATTACH_TO_CATEGORY = "ProcessType"
@@ -383,6 +384,7 @@ class StepDetails(IOMapsMixin, FieldsMixin, ClarityElement):
     IOMAPS_OUTPUT_TYPE_ATTRIBUTE = "type"
 
     name = subnode_property("configuration", readonly=True)
+    instrument_used = subnode_link(Instrument, "instrument", readonly=True, attributes=('uri',))
 
     def __init__(self, step, *args, **kwargs):
         self.step = step
@@ -415,16 +417,6 @@ class StepDetails(IOMapsMixin, FieldsMixin, ClarityElement):
 
     def _get_iomaps_shared_result_file_type(self):
         return "ResultFile"
-
-    @lazy_property
-    def instrument_used(self):
-        """
-        :type: Instrument
-        """
-        instrument_node = self.xml_find("./instrument")
-        if instrument_node is None:
-            return None
-        return Instrument(lims=self.lims, uri=instrument_node.get("uri"))
 
 
 class StepPools(ClarityElement):

--- a/s4/clarity/test/generic_testcases.py
+++ b/s4/clarity/test/generic_testcases.py
@@ -40,8 +40,11 @@ class FakeFactory:
         self.instances = {}
 
     def from_link_node(self, linknode):
-        uri = linknode.get("uri")
 
+        if linknode is None:
+            return None
+
+        uri = linknode.get("uri")
         if uri in self.instances:
             return self.instances[uri]
 

--- a/s4/clarity/test/s4/clarity/test_instrument.py
+++ b/s4/clarity/test/s4/clarity/test_instrument.py
@@ -6,24 +6,36 @@ from s4.clarity.step import Step, StepDetails
 
 from s4.clarity.test.generic_testcases import LimsTestCase
 
+from datetime import date  # typing
 from s4.clarity.utils.date_util import str_to_date
 
 
 class TestInstrument(LimsTestCase):
 
     def test_instrument_assignment_on_step_details(self):
+        """
+        Test for Instrument set in the 'Instrument Field' value during the Step Details phase
+        """
 
-        step = self.element_from_xml(Step, STEP_XML)
-        step_details = self.element_from_xml(StepDetails, PRE_INSTRUMENT_SET_STEP_DETAILS_XML, step=step)
+        # Parse the xml into a StepDetails object
+        step = self.element_from_xml(Step, STEP_XML)  # type: Step
+
+        # pre instrument used field set
+        step_details = self.element_from_xml(StepDetails, PRE_INSTRUMENT_SET_STEP_DETAILS_XML, step=step)  # type: StepDetails
         self.assertIsNone(step_details.instrument_used)
 
+        # post instrument used field set
         step_details = self.element_from_xml(StepDetails, POST_INSTRUMENT_SET_STEP_DETAILS_XML, step=step)
         self.assertIsInstance(step_details.instrument_used, Instrument)
 
     def test_instrument_object_properties(self):
+        """
+        Test for Instrument object instantiation (Clarity Element inherits WrappedXml class)
+        Point of Interest: Instrument API endpoint only permits GET
+        """
 
-        # Parse the xml into a StepDetails object
-        instrument = self.element_from_xml(Instrument, INSTRUMENT_XML)
+        # Parse the xml into an Instrument object
+        instrument = self.element_from_xml(Instrument, INSTRUMENT_XML)  # type: Instrument
 
         self.assertEqual(instrument.name, "instrument_2")
         self.assertEqual(instrument.limsid, "4")
@@ -32,7 +44,7 @@ class TestInstrument(LimsTestCase):
         self.assertEqual(instrument.archived, False)
 
         clarity_date_time_str = "2021-12-06"
-        expected_date = str_to_date(clarity_date_time_str)
+        expected_date = str_to_date(clarity_date_time_str)  # type: date
 
         self.assertEqual(instrument.expiry_date, expected_date)
 

--- a/s4/clarity/test/s4/clarity/test_instrument.py
+++ b/s4/clarity/test/s4/clarity/test_instrument.py
@@ -26,7 +26,7 @@ class TestInstrument(LimsTestCase):
 
         # post instrument used field set
         step_details = self.element_from_xml(StepDetails, POST_INSTRUMENT_SET_STEP_DETAILS_XML, step=step)
-        self.assertIsInstance(step_details.instrument_used, Instrument)
+        self.assertIsNotNone(step_details.instrument_used)
 
     def test_instrument_object_properties(self):
         """

--- a/s4/clarity/test/s4/clarity/test_instrument.py
+++ b/s4/clarity/test/s4/clarity/test_instrument.py
@@ -1,0 +1,118 @@
+# Copyright 2021 Semaphore Solutions, Inc.
+# ---------------------------------------------------------------------------
+
+from s4.clarity.instrument import Instrument
+from s4.clarity.step import Step, StepDetails
+
+from s4.clarity.test.generic_testcases import LimsTestCase
+
+from s4.clarity.utils.date_util import str_to_date
+
+
+class TestInstrument(LimsTestCase):
+
+    def test_instrument_assignment_on_step_details(self):
+
+        step = self.element_from_xml(Step, STEP_XML)
+        step_details = self.element_from_xml(StepDetails, PRE_INSTRUMENT_SET_STEP_DETAILS_XML, step=step)
+        self.assertIsNone(step_details.instrument_used)
+
+        step_details = self.element_from_xml(StepDetails, POST_INSTRUMENT_SET_STEP_DETAILS_XML, step=step)
+        self.assertIsInstance(step_details.instrument_used, Instrument)
+
+    def test_instrument_object_properties(self):
+
+        # Parse the xml into a StepDetails object
+        instrument = self.element_from_xml(Instrument, INSTRUMENT_XML)
+
+        self.assertEqual(instrument.name, "instrument_2")
+        self.assertEqual(instrument.limsid, "4")
+        self.assertEqual(instrument.instrument_type, "Instrument ABC")
+        self.assertEqual(instrument.serial_number, "2222")
+        self.assertEqual(instrument.archived, False)
+
+        clarity_date_time_str = "2021-12-06"
+        expected_date = str_to_date(clarity_date_time_str)
+
+        self.assertEqual(instrument.expiry_date, expected_date)
+
+
+STEP_XML = \
+    """
+    <stp:step xmlns:stp="http://genologics.com/ri/step" current-state="Record Details" limsid="24-6859" uri="https://qalocal/api/v2/steps/24-6859">
+    <configuration uri="https://qalocal/api/v2/configuration/protocols/12/steps/29">Visual QC</configuration>
+    <date-started>2021-11-24T11:06:46.014-08:00</date-started>
+    <actions uri="https://qalocal/api/v2/steps/24-6859/actions"/>
+    <details uri="https://qalocal/api/v2/steps/24-6859/details"/>
+    <available-programs/>
+    </stp:step>
+    """
+
+PRE_INSTRUMENT_SET_STEP_DETAILS_XML = \
+    """
+    <stp:details xmlns:udf="http://genologics.com/ri/userdefined" xmlns:stp="http://genologics.com/ri/step" uri="https://qalocal/api/v2/steps/24-6859/details">
+    <step uri="https://qalocal/api/v2/steps/24-6859" rel="steps"/>
+    <configuration uri="https://qalocal/api/v2/configuration/protocols/12/steps/29">Visual QC</configuration>
+    <input-output-maps>
+    <input-output-map>
+    <input uri="https://qalocal/api/v2/artifacts/1C-752PA1" limsid="1C-752PA1"/>
+    <output uri="https://qalocal/api/v2/artifacts/92-55059" output-generation-type="PerAllInputs" type="ResultFile" limsid="92-55059"/>
+    </input-output-map>
+    </input-output-maps>
+    <fields/>
+    </stp:details>
+    """
+
+POST_INSTRUMENT_SET_STEP_DETAILS_XML = \
+    """
+    <stp:details xmlns:udf="http://genologics.com/ri/userdefined" xmlns:stp="http://genologics.com/ri/step" uri="https://qalocal/api/v2/steps/24-6859/details">
+    <step uri="https://qalocal/api/v2/steps/24-6859" rel="steps"/>
+    <configuration uri="https://qalocal/api/v2/configuration/protocols/12/steps/29">Visual QC</configuration>
+    <input-output-maps>
+    <input-output-map>
+    <input uri="https://qalocal/api/v2/artifacts/1C-752PA1" limsid="1C-752PA1"/>
+    <output uri="https://qalocal/api/v2/artifacts/92-55059" output-generation-type="PerAllInputs" type="ResultFile" limsid="92-55059"/>
+    </input-output-map>
+    </input-output-maps>
+    <fields/>
+    <instrument uri="https://qalocal/api/v2/instruments/4">instrument_2</instrument>
+    </stp:details>
+    """
+
+INSTRUMENTS_XML = \
+    """
+    <inst:instruments xmlns:inst="http://genologics.com/ri/instrument">
+    <instrument uri="https://qalocal/api/v2/instruments/2">
+    <name>non_an_instrument</name>
+    </instrument>
+    <instrument uri="https://qalocal/api/v2/instruments/3">
+    <name>instrument_1</name>
+    </instrument>
+    <instrument uri="https://qalocal/api/v2/instruments/4">
+    <name>instrument_2</name>
+    </instrument>
+    <instrument uri="https://qalocal/api/v2/instruments/5">
+    <name>instrument_3</name>
+    </instrument>
+    <instrument uri="https://qalocal/api/v2/instruments/6">
+    <name>instrument_a</name>
+    </instrument>
+    <instrument uri="https://qalocal/api/v2/instruments/7">
+    <name>instrument_b</name>
+    </instrument>
+    <instrument uri="https://qalocal/api/v2/instruments/8">
+    <name>instrument_c</name>
+    </instrument>
+    </inst:instruments>
+    """
+
+INSTRUMENT_XML = \
+    """
+    <inst:instrument xmlns:inst="http://genologics.com/ri/instrument" limsid="55-4" uri="https://qalocal/api/v2/instruments/4">
+    <name>instrument_2</name>
+    <type>Instrument ABC</type>
+    <serial-number>2222</serial-number>
+    <expiry-date>2021-12-06</expiry-date>
+    <archived>false</archived>
+    </inst:instrument>
+    """


### PR DESCRIPTION
+ Adds a new `Instrument` object to relationally map to the [Clarity Instruments API endpoint](https://d10e8rzir0haj8.cloudfront.net/5.3/rest.version.instruments.html)
+ Updates `StepConfiguration` (in `configuration.protcol`) and `StepDetails` (in `step`) to retrieve `instrument` related xml subnodes
+ Adds some tests for the Instrument object
+ I doubt `Instruments` will get much use (at least it shouldn't based on a shallow analysis). However, in a universe of possibilities, some client is certainly going to argue for a use case i.e. if it's built, they will come...