### PR TITLE
typing install based on python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ argparse
 python-dateutil
 six>=1.12
 future
-typing
+typing;python_version<"3.5"
 
 # Test requirements
 mock

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'python-dateutil',
         'six',
         'future',
-        'typing'
+        "typing; python_version < '3.5'"
     ),
     tests_require=(
         'mock',


### PR DESCRIPTION
**Context**
Addressing issue raised by [Joshua Shapiro (Cradle Genomics)](https://github.com/SemaphoreSolutions/s4-clarity-lib/issues/26)
The `typing` module is built-in to Python versions 3.5 + . See: https://pypi.org/project/typing/

**PR**
This PR is to update package installation features re: `typing`