### PR TITLE
The 'step' property on a Stage actually returns a StepConfiguration, not a step

### DIFF
--- a/s4/clarity/configuration/stage.py
+++ b/s4/clarity/configuration/stage.py
@@ -27,7 +27,7 @@ class Stage(ClarityElement):
     @lazy_property
     def step(self):
         """
-        :type: Step
+        :type: StepConfiguration
         """
         step_node = self.xml_find("step")
         if step_node is not None:


### PR DESCRIPTION
Fixing a typo in the documentation that tripped me up for an hour this afternoon.

The "step" property of a Stage object actually returns a StepConfiguration object, not a Step object.  Here's an XML example of a Stage from the Clarity API (taken from version 5.2.2) - note that while the tag is named `step`, the `uri` attribute is actually pointing to the configuration.

```
<stg:stage xmlns:stg="http://genologics.com/ri/stage" index="0" name="Microdissection" uri="https://qalocal/api/v2/configuration/workflows/77/stages/2004">
    <workflow uri="https://qalocal/api/v2/configuration/workflows/77"/>
    <protocol uri="https://qalocal/api/v2/configuration/protocols/41"/>
    <step uri="https://qalocal/api/v2/configuration/protocols/41/steps/117"/>
</stg:stage>
```