### PR TITLE
Fix workflow.enqueue() setting 'stage-uri' in generated XML if 'stage' appears in domain

### DIFF
--- a/s4/clarity/routing.py
+++ b/s4/clarity/routing.py
@@ -98,7 +98,7 @@ class Router(object):
         """
         Generates a ElementTree.SubElement according to the action (assign / unassign) and the workflow/stage uri
         """
-        if 'stage' in workflow_or_stage_uri:
+        if '/stage/' in workflow_or_stage_uri:
             assign_node = ETree.SubElement(routing_node, action, {'stage-uri': workflow_or_stage_uri})
         else:
             assign_node = ETree.SubElement(routing_node, action, {'workflow-uri': workflow_or_stage_uri})


### PR DESCRIPTION
This fixes a bug that came up with one of our customers, when they were performing QA on their staging server.

This customer was attempting to enqueue newly accessioned samples to a particular workflow, like this:
```
workflow = self.lims.workflows.query(name=workflow_name)[0]
workflow.enqueue(sample.artifact)
```

While this worked fine on their development server (let's call it `dev.example.com`), it failed on their staging server (`stage.example.com`) with the following error:
```
Invalid stage-uri: https://stage.example.com/api/v2/configuration/workflows/623
```

More specifically, the generated XML payload looked like this:
```
<ns0:routing xmlns:ns0=http://genologics.com/ri/routing><assign stage-uri=https://stage.example.com/api/v2/configuration/workflows/623><artifact uri=https://stage.example.com/api/v2/artifacts/ADM1604A130PA1 /></assign></ns0:routing>
```
the cause of error being that `<assign stage-uri` is used with a _workflow_ uri, when `<assign workflow-uri` should have been used instead.

After an extensive debugging session, we tracked down the flawed logic in the `_add_action_subnode` method of the `Router` class. This method looks for the string `stage` in the URI to determine if `stage-uri` or `workflow-uri` should be used in the generated XML. Because this customer used `stage` as the name of their subdomain, it caused this function to incorrectly select `stage-uri` instead of `workflow-uri`!

```
def _add_action_subnode(self, routing_node, action, workflow_or_stage_uri):
        """
        Generates a ElementTree.SubElement according to the action (assign / unassign) and the workflow/stage uri
        """
        if 'stage' in workflow_or_stage_uri:
            assign_node = ETree.SubElement(routing_node, action, {'stage-uri': workflow_or_stage_uri})
        else:
            assign_node = ETree.SubElement(routing_node, action, {'workflow-uri': workflow_or_stage_uri})

        return assign_node
```

This has been fixed (and hot-patched for the customer) by changing the line:
`if 'stage' in workflow_or_stage_uri:`
to the following:
`if '/stage/' in workflow_or_stage_uri:`
which will only match `stage` if it appears in the path of the URI.

The customer has confirmed that this fixes their issue.