### PR TITLE
Adding compatibility with python versions 3.9, 3.10, 3.11

### DIFF
--- a/s4/clarity/_internal/fields.py
+++ b/s4/clarity/_internal/fields.py
@@ -5,8 +5,12 @@ import collections
 from six import string_types
 from . import ClarityElement
 from s4.clarity import ETree, types
-from .lazy_property import  lazy_property
+from .lazy_property import lazy_property
 from s4.clarity.types import obj_to_clarity_string, clarity_string_to_obj
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 FIELD_TAG = "{http://genologics.com/ri/userdefined}field"
 
@@ -160,7 +164,7 @@ class FieldsMixin(ClarityElement):
                     subnode.text = subnode.text.replace(',', '.')
 
 
-class FieldsDict(collections.MutableMapping):
+class FieldsDict(MutableMapping):
     """
     :type _real_dict: dict[str, ETree.Element]
     :type _root_node: ETree.Element

--- a/s4/clarity/_internal/props.py
+++ b/s4/clarity/_internal/props.py
@@ -6,7 +6,10 @@ import logging
 import inspect
 from six import string_types
 from abc import ABCMeta, abstractmethod
-from collections import MutableSequence, MutableMapping
+try:
+    from collections.abc import MutableSequence, MutableMapping
+except ImportError:
+    from collections import MutableSequence, MutableMapping
 
 from s4.clarity import types
 

--- a/s4/clarity/iomaps.py
+++ b/s4/clarity/iomaps.py
@@ -69,8 +69,8 @@ class IOMapsMixin(ClarityElement):
                            self.input_keyed_lookup.items()]
 
         # Prepare our artifact lists
-        self.inputs = list(self.input_keyed_lookup.keys())
-        self.outputs = list(self.output_keyed_lookup.keys())
+        self.inputs = list(self.input_keyed_lookup)
+        self.outputs = list(self.output_keyed_lookup)
         self.shared_outputs = list(shared_output_set)
 
     def _get_iomaps_shared_result_file_type(self):

--- a/s4/clarity/queue.py
+++ b/s4/clarity/queue.py
@@ -18,7 +18,7 @@ class Queue(ClarityElement):
     def query(self, prefetch=True, **params):
         queued_elements = []
 
-        for k in params.keys():
+        for k in params:
             if "_" in k:
                 new_k = k.replace("_", "-")
                 params[new_k] = params[k]

--- a/s4/clarity/scripts/genericscript.py
+++ b/s4/clarity/scripts/genericscript.py
@@ -144,7 +144,7 @@ class GenericScript(object):
                     level_name_dict = logging._levelNames
                 msg = "%r is not a valid log level: use one of %s" % (
                     string,
-                    list(filter(lambda k: type(k) == str, level_name_dict.keys()))
+                    list(filter(lambda k: type(k) == str, list(level_name_dict)))
                 )
                 raise argparse.ArgumentTypeError(msg)
 

--- a/s4/clarity/scripts/triggered_step_epp.py
+++ b/s4/clarity/scripts/triggered_step_epp.py
@@ -63,7 +63,7 @@ class TriggeredStepEPP(StepEPP):
     def add_arguments(cls, argparser):
         super(TriggeredStepEPP, cls).add_arguments(argparser)
         cls.add_triggered_step_actions()
-        argparser.add_argument("-a", "--action", choices=cls.triggered_step_actions.keys(), required=True)
+        argparser.add_argument("-a", "--action", choices=list(cls.triggered_step_actions), required=True)
 
     def run(self):
         log.info("Handling Action '%s'" % self.options.action)

--- a/s4/clarity/steputils/step_runner.py
+++ b/s4/clarity/steputils/step_runner.py
@@ -362,7 +362,7 @@ class StepRunner:
             def filterfunc(aa):
                 return (aa.action == "nextstep" and aa.step_uri == self.step_config.uri) or aa.action == "complete"
 
-        return [aa.artifact_uri for aa in filter(filterfunc, artifact_actions.values())]
+        return [aa.artifact_uri for aa in filter(filterfunc, list(artifact_actions.values()))]
 
     def get_started_step(self, previous_step, project_name):
         return previous_step.automatic_next_step.limsid

--- a/s4/clarity/test/s4/clarity/_internal/test_props.py
+++ b/s4/clarity/test/s4/clarity/_internal/test_props.py
@@ -1,6 +1,9 @@
 import string
-from collections import MutableSet
 
+try:
+    from collections.abc import MutableSet
+except ImportError:
+    from collections import MutableSet
 from s4.clarity import types, ETree
 from s4.clarity._internal import WrappedXml
 from s4.clarity._internal.props import attribute_property, subnode_property, subnode_link, subnode_links, subnode_element, subnode_property_literal_dict, subnode_property_dict, subnode_element_list

--- a/s4/clarity/test/s4/clarity/test_container.py
+++ b/s4/clarity/test/s4/clarity/test_container.py
@@ -65,7 +65,7 @@ class TestContainer(LimsTestCase):
         self.assertEqual(container.occupied_wells, 22)
         self.assertEqual(container.state, "Populated")
         self.assertEqual(container.type_name, "48 well plate")
-        self.assertEqual(len(container.placements.keys()), 22)
+        self.assertEqual(len(list(container.placements)), 22)
         self.assertEqual(container.placements["E:2"].limsid, "2-7628")
         self.assertEqual(container.placements["C:1"].limsid, "2-7620")
 

--- a/s4/clarity/test/s4/clarity/test_container.py
+++ b/s4/clarity/test/s4/clarity/test_container.py
@@ -65,7 +65,7 @@ class TestContainer(LimsTestCase):
         self.assertEqual(container.occupied_wells, 22)
         self.assertEqual(container.state, "Populated")
         self.assertEqual(container.type_name, "48 well plate")
-        self.assertEqual(len(list(container.placements)), 22)
+        self.assertEqual(len(container.placements), 22)
         self.assertEqual(container.placements["E:2"].limsid, "2-7628")
         self.assertEqual(container.placements["C:1"].limsid, "2-7620")
 

--- a/s4/clarity/test/test_iomaps.py
+++ b/s4/clarity/test/test_iomaps.py
@@ -130,10 +130,10 @@ class TestIomaps(LimsTestCase):
         self.assertEqual(self.artifact_dict_to_limsids_dict(details.iomaps_output_keyed()), expected_output_map)
 
         # Verify that the input and output names match and there are no extra or missing names
-        input_names = expected_input_map.keys()
+        input_names = list(expected_input_map)
         self._verify_names(details.inputs, input_names)
 
-        output_names = expected_output_map.keys()
+        output_names = list(expected_output_map)
         self._verify_names(details.outputs, output_names)
 
         # Check that the iomaps look like we expect them too

--- a/s4/clarity/utils/artifact_ancestry.py
+++ b/s4/clarity/utils/artifact_ancestry.py
@@ -105,8 +105,8 @@ def _get_udfs_from_ancestors_internal(lims, current_artifacts_to_original_artifa
     get filled in over the recursive calls of this method.
     :rtype: dict[s4.clarity.Artifact, dict[str, Any]]
     """
-    current_artifacts = current_artifacts_to_original_artifacts.keys()
-    current_artifacts_to_parent_artifacts = get_parent_artifacts(lims, current_artifacts_to_original_artifacts.keys())
+    current_artifacts = list(current_artifacts_to_original_artifacts)
+    current_artifacts_to_parent_artifacts = get_parent_artifacts(lims, list(current_artifacts_to_original_artifacts))
 
     # Initialize the 'next to search' dict
     next_search_artifacts_to_original_artifacts = defaultdict(list)

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,13 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],
     install_requires=(


### PR DESCRIPTION
As developers, we would like to be able to use the s4-clarity library with new versions of the python interpreter. We ask you to consider our changes, as we would like to contribute to the development of this library.