### PR TITLE
Allow the --insecure parameter to be used together with --dry-run

### DIFF
--- a/s4/clarity/lims.py
+++ b/s4/clarity/lims.py
@@ -173,10 +173,10 @@ class LIMS(object):
             s = FakeSession()
         else:
             s = requests.Session()
-            if self._insecure:
-                log.warning("WARNING - This machine is not validating SSL certificates. DO NOT ENABLE IN PRODUCTION.")
-                urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-                s.verify = False
+        if self._insecure:
+            log.warning("WARNING - This machine is not validating SSL certificates. DO NOT ENABLE IN PRODUCTION.")
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+            s.verify = False
 
         s.auth = (self.username, self.password)
         return s


### PR DESCRIPTION
When a LIMS object is instantiated with `dry_run=True`, the value of the `insecure` parameter will be ignored. This means that testing scripts against a local VM which make use of the `--dry-run` parameter will likely fail, as most local VMs use self-signed SSL certificates that don't pass validation (and thus require `--insecure`).

This occurs due to an indentation error in `lims.py` and is a trivial fix.