### PR TITLE
Enable testing for Python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
     - '3.7'
     - '3.8'
     - '3.9'
+    - '3.10'
 
 before_install:
   - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pip install -U importlib_metadata ; fi  # workaround
@@ -29,4 +30,4 @@ deploy:
         secure: mbGQtNQAdtpfR3tcF0jObnU0XlWuxrt3DJ3zaRwJa6VrWj6xaVGVX+l4KzRoKmIjsbMuvVNyt1+1ZdPf/SlXLaSwvA/gwyo2vaI3w5WhTAwXjnfaBjs3AfiWAdJFDz2r8pKW2aP1uIP22wFC5hh+JAvudLr9z/3S7v2Y9oK7K0fIeXNC29q9MctqEqLgn6+drz1wcGFtu+GReJlwz+q9veAqUkDHlDDIYeRXhfxq+wUF3JdFxveHgt1FqZvJK9NvcQ/IlEXD13fjuXYEgtlzJtrSOSYrSyIquczmr59/IltDvqzvmtMdqYhKhuJ9sqvzmqUWHBpVA5wABY+H9wF5Z3jk7PLyJ3PdwAH3cTsfjVaxdJZydoFuUEhPXwhZMd9E3V47g/OKRezoMvdP89Gb038zt4sGgv6m8U0oxgA3VzKaWwrLn+mhR8ltUzWiRQyqWHMhluDWF+EYsUhfaItlc0QdkSnQSRi5eVXOBoq9+mm4qC8xz1dxK6CP8pbKXy/Np9Y+fdR8/0c7CrNL4CpX2jPhjxnBexQViteLaXyN9cQA9xPk0RjWUtmnDflV4UJMMcsyWPaF9jzrTDGS8uUhEI7qSWjnNnfQb3+CThu/L4SDw/fsEov4tvcOzBwYPL5bbidZMs4BRo9HLtxba1Jt7pA5OvH+f4eT/vk+OP7cvMc=
     on:
         tags: true
-        python: '3.9'
+        python: '3.10'


### PR DESCRIPTION
(Note: The Travis check for this PR is expected to fail, because the s4-clarity-lib code doesn't currently run on Python 3.10. This PR is just to enable testing against 3.10, so that when #34 is merged we can verify it).