### PR TITLE
Fix EPP log message duplication and missing log entries in Clarity 6+ when combining Python automations with LLTK/LITKs

### DIFF
--- a/s4/clarity/lims.py
+++ b/s4/clarity/lims.py
@@ -274,7 +274,8 @@ class LIMS(object):
         path = urlparse.urlparse(self.root_uri).path
         current_major_version = [x for x in path.split("/") if x][-1]
         root = self.request("get", self.root_uri + "/..")
-        version = root.findall(f"version[@major='{current_major_version}']")[0]
+        xpath = "version[@major='%s']" % current_major_version
+        version = root.findall(xpath)[0]
         return version.get("minor")
 
     def raw_request(self, method, uri, **kwargs):

--- a/s4/clarity/lims.py
+++ b/s4/clarity/lims.py
@@ -3,6 +3,12 @@
 import logging
 import re
 import time
+
+try:
+    import urllib.parse as urlparse  # Python 3
+except ImportError:
+    import urlparse  # Python 2
+
 from xml.etree import cElementTree as ETree
 
 import requests
@@ -246,6 +252,30 @@ class LIMS(object):
         root = self.request("get", self.root_uri + "/configuration/properties" )
         properties = root.findall("property")
         return dict( (property.get("name"), property.get("value")) for property in properties )
+
+    @lazy_property
+    def versions(self):
+        """
+        :type: list[dict]
+        """
+        root = self.request("get", self.root_uri + "/..")
+        versions = root.findall("version")
+        return list({
+            "uri": version.get("uri"),
+            "major": version.get("major"),
+            "minor": version.get("minor")
+        } for version in versions)
+
+    @lazy_property
+    def current_minor_version(self):
+        """
+        :type: str
+        """
+        path = urlparse.urlparse(self.root_uri).path
+        current_major_version = [x for x in path.split("/") if x][-1]
+        root = self.request("get", self.root_uri + "/..")
+        version = root.findall(f"version[@major='{current_major_version}']")[0]
+        return version.get("minor")
 
     def raw_request(self, method, uri, **kwargs):
         """

--- a/s4/clarity/scripts/stepepp.py
+++ b/s4/clarity/scripts/stepepp.py
@@ -53,11 +53,24 @@ class StepEPP(GenericScript):
         Use step's logfile.
         """
         if self.options.logfile:
+
+            # Log files that are shared by Python and LLTK/LITKs on a step must
+            # use the same file name in order to prevent bugs. In Clarity 5 and
+            # earlier, the file name used by LLTK/LITKs is simply the limsid of
+            # the ResultFile. But in Clarity 6 and later it has "LogFile"
+            # appended to the name, and so we need to check the active Clarity
+            # version and adjust our behaviour accordingly.
+
+            filename = self.options.logfile
+            revision = int(self.lims.current_minor_version[1:])
+            if revision >= 31:  # Clarity 6.0 has an API minor version of 31
+                filename = "%s-LogFile" % filename
+
             if self.options.log_type == 'html':
-                filename = "%s.html" % self.options.logfile
+                filename = "%s.html" % filename
                 content_type = 'text/html'
             elif self.options.log_type == 'text':
-                filename = "%s.log" % self.options.logfile
+                filename = "%s.log" % filename
                 content_type = 'text/plain'
             else:
                 raise Exception("Unrecognized log type %s", self.options.log_type)


### PR DESCRIPTION
In Clarity LIMS 6.0 and above, when writing an automation for a step that:
 - executes both a Python script as well as a Java-based LLTK or LITK, and
 - both the Python script and LLTK/LITK are writing a log file to the same ResultFile placeholder

then in some cases, log messages can either become duplicated - resulting in extra large log files - or missing. This behaviour seems to depend on the order in which the scripts are executed as part of the automation.

An example that exhibits such behaviour is as follows:
```
bash -c "/opt/gls/clarity/customextensions/env/bin/python /opt/gls/clarity/customextensions/set_qc.py -u {username} -p {password} --step-uri {stepURI} -l {compoundOutputFileLuid0} && /opt/gls/clarity/bin/java -jar /opt/gls/clarity/extensions/ngs-common/v5/EPP/ngs-extensions.jar -i {stepURI:v2:http} -u {username} -p {password} script:evaluateDynamicExpression -t false -h true -exp 'if (output.QC == true) { nextStep = ::ADVANCE:: } else { nextStep = ::REMOVE:: }' -log {compoundOutputFileLuid0}"
```

The root cause of this issue is due to the fact that in Clarity 6, the log file name for LLTK/LITKs was changed to include `LogFile` as part of the file name, and not just the ResultFile LimsID.  Thus, in order to squash this bug, the s4-clarity library needs to be updated to:
 - detect the version of Clarity that is currently in use, and
 - determine the correct file name to use for log files depending on the Clarity version.

As part of this, I have added a couple of new properties to the `s4.clarity.LIMS` object:
`s4.clarity.LIMS.versions` - returns a list of all API versions supported by the active version of Clarity LIMS
`s4.clarity.LIMS.current_minor_version` - returns the minor version ("revision") of the active Clarity LIMS API version.