### PR TITLE
Fix coveralls on Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
         run: |
           pytest --cov=s4
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.0
+        with:
+          coverage-reporter-version: v0.6.6
 
   # Use a container to run Python 2 (host OS doesn't matter)
   # required because the setup-python action dropped support for python 2


### PR DESCRIPTION
Pin coverage-reporter-version in CI to v0.6.6 as newer versions are no longer compatible with Python 3.6