### PR TITLE
StepRunner: ignore archived reagent kits when adding default reagents to a step

### DIFF
--- a/s4/clarity/lims.py
+++ b/s4/clarity/lims.py
@@ -274,7 +274,8 @@ class LIMS(object):
         path = urlparse.urlparse(self.root_uri).path
         current_major_version = [x for x in path.split("/") if x][-1]
         root = self.request("get", self.root_uri + "/..")
-        version = root.findall(f"version[@major='{current_major_version}']")[0]
+        xpath = "version[@major='%s']" % current_major_version
+        version = root.findall(xpath)[0]
         return version.get("minor")
 
     def raw_request(self, method, uri, **kwargs):

--- a/s4/clarity/lims.py
+++ b/s4/clarity/lims.py
@@ -3,6 +3,12 @@
 import logging
 import re
 import time
+
+try:
+    import urllib.parse as urlparse  # Python 3
+except ImportError:
+    import urlparse  # Python 2
+
 from xml.etree import cElementTree as ETree
 
 import requests
@@ -246,6 +252,30 @@ class LIMS(object):
         root = self.request("get", self.root_uri + "/configuration/properties" )
         properties = root.findall("property")
         return dict( (property.get("name"), property.get("value")) for property in properties )
+
+    @lazy_property
+    def versions(self):
+        """
+        :type: list[dict]
+        """
+        root = self.request("get", self.root_uri + "/..")
+        versions = root.findall("version")
+        return list({
+            "uri": version.get("uri"),
+            "major": version.get("major"),
+            "minor": version.get("minor")
+        } for version in versions)
+
+    @lazy_property
+    def current_minor_version(self):
+        """
+        :type: str
+        """
+        path = urlparse.urlparse(self.root_uri).path
+        current_major_version = [x for x in path.split("/") if x][-1]
+        root = self.request("get", self.root_uri + "/..")
+        version = root.findall(f"version[@major='{current_major_version}']")[0]
+        return version.get("minor")
 
     def raw_request(self, method, uri, **kwargs):
         """

--- a/s4/clarity/scripts/stepepp.py
+++ b/s4/clarity/scripts/stepepp.py
@@ -53,11 +53,24 @@ class StepEPP(GenericScript):
         Use step's logfile.
         """
         if self.options.logfile:
+
+            # Log files that are shared by Python and LLTK/LITKs on a step must
+            # use the same file name in order to prevent bugs. In Clarity 5 and
+            # earlier, the file name used by LLTK/LITKs is simply the limsid of
+            # the ResultFile. But in Clarity 6 and later it has "LogFile"
+            # appended to the name, and so we need to check the active Clarity
+            # version and adjust our behaviour accordingly.
+
+            filename = self.options.logfile
+            revision = int(self.lims.current_minor_version[1:])
+            if revision >= 31:  # Clarity 6.0 has an API minor version of 31
+                filename = "%s-LogFile" % filename
+
             if self.options.log_type == 'html':
-                filename = "%s.html" % self.options.logfile
+                filename = "%s.html" % filename
                 content_type = 'text/html'
             elif self.options.log_type == 'text':
-                filename = "%s.log" % self.options.logfile
+                filename = "%s.log" % filename
                 content_type = 'text/plain'
             else:
                 raise Exception("Unrecognized log type %s", self.options.log_type)

--- a/s4/clarity/steputils/step_runner.py
+++ b/s4/clarity/steputils/step_runner.py
@@ -340,10 +340,15 @@ class StepRunner:
         """
         For every required reagent kit in the step, the first active lot
         will be selected. If there are no active lots it will be omitted.
+
+        Archived kits will be ignored on Clarity 6.1 (api revision 32) and later.
         """
+        revision = int(self.lims.current_minor_version[1:])
         log.info("Adding default reagent lots.")
         lots = []
         for kit in self.step.configuration.required_reagent_kits:
+            if revision >= 32 and kit.archived:
+                continue
             for lot in kit.related_reagent_lots:
                 if lot.status == "ACTIVE":
                     lots.append(lot)


### PR DESCRIPTION
If a reagent kit is associated to a step, and is later archived, then when running the step manually using the Clarity GUI, the reagent kit will (correctly) not be shown on the step's Record Details screen.

However, the association between the step and archived kit is retained, and when making an API request using something like self.step.configuration.required_reagent_kits, the archived kit will be returned by the API.

If the API is then used to add a lot to the archived kit on the step, and advance the step, the Clarity API will correctly - but confusingly - return an error stating that the reagent kit is not permitted for the step.

This patch modifies the add_default_reagents() function of the StepRunner to ignore any reagent kits found on the step that are archived, instead of adding a lot to them. This prevents workflow tests from suddenly breaking because a customer decided to archive a reagent kit without removing it from a step first.