### PR TITLE
check for placement node that matches uri before creating one

### DIFF
--- a/.github/workflows/cd-test.yml
+++ b/.github/workflows/cd-test.yml
@@ -13,11 +13,11 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Build s4-clarity-lib

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: Publish to PyPi
 on:
   push:
     tags:
-      - '*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build_and_deploy:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,11 +13,11 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Build s4-clarity-lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -40,7 +40,7 @@ jobs:
     container: python:2.7.18-buster
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Before tests (same as "before_install")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,27 @@ jobs:
         with:
           coverage-reporter-version: v0.6.6
 
+  # Use a container to run Python 3.5 (host OS doesn't matter)
+  # required because of SSL cert errors in pip when running in the setup-python action
+  # Don't bother with coveralls here, just run the tests
+  test-python35:
+    runs-on: ubuntu-latest
+    container: python:3.5.10-buster
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Before tests (same as "before_install")
+        run: |
+          pip install --upgrade -r requirements.txt
+      - name: Run test suite (same as "script")
+        run: |
+          pytest --cov=s4
+
   # Use a container to run Python 2 (host OS doesn't matter)
   # required because the setup-python action dropped support for python 2
-  # Don't bother with coveralls or pypi here, just run the tests
+  # Don't bother with coveralls here, just run the tests
   test-python2:
     runs-on: ubuntu-latest
     container: python:2.7.18-buster

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,17 @@ jobs:
       - name: Coveralls
         uses: coverallsapp/github-action@v2.3.0
         with:
+          parallel: true
           coverage-reporter-version: v0.6.6
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close parallel build
+        uses: coverallsapp/github-action@v2.3.0
+        with:
+          parallel-finished: true
 
   # Use a container to run Python 3.5 (host OS doesn't matter)
   # required because of SSL cert errors in pip when running in the setup-python action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04  # last version that can run Python 3.6
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
         run: |
           pytest --cov=s4
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.0
+        with:
+          coverage-reporter-version: v0.6.6
 
   # Use a container to run Python 2 (host OS doesn't matter)
   # required because the setup-python action dropped support for python 2

--- a/s4/clarity/step.py
+++ b/s4/clarity/step.py
@@ -534,7 +534,9 @@ class StepPlacements(ClarityElement):
         :param well_string: The location on the plate to place the artifact
         """
         placement_root = self.xml_root.find("./output-placements")
-        placement_node = ETree.SubElement(placement_root, "output-placement", {"uri": artifact.uri})
+        placement_node = self.xml_root.find(f"./output-placements/output-placement[@uri={artifact.uri}]")
+        if not placement_node:
+            placement_node = ETree.SubElement(placement_root, "output-placement", {"uri": artifact.uri})
         location_subnode = ETree.SubElement(placement_node, "location")
         ETree.SubElement(location_subnode, "container", {"uri": container.uri})
         ETree.SubElement(location_subnode, "value").text = well_string

--- a/s4/clarity/step.py
+++ b/s4/clarity/step.py
@@ -534,7 +534,7 @@ class StepPlacements(ClarityElement):
         :param well_string: The location on the plate to place the artifact
         """
         placement_root = self.xml_root.find("./output-placements")
-        placement_node = self.xml_root.find(f"./output-placements/output-placement[@uri='" + artifact.uri + "']")
+        placement_node = self.xml_root.find("./output-placements/output-placement[@uri='" + artifact.uri + "']")
         if not placement_node:
             placement_node = ETree.SubElement(placement_root, "output-placement", {"uri": artifact.uri})
         location_subnode = ETree.SubElement(placement_node, "location")

--- a/s4/clarity/step.py
+++ b/s4/clarity/step.py
@@ -534,7 +534,7 @@ class StepPlacements(ClarityElement):
         :param well_string: The location on the plate to place the artifact
         """
         placement_root = self.xml_root.find("./output-placements")
-        placement_node = self.xml_root.find(f"./output-placements/output-placement[@uri={artifact.uri}]")
+        placement_node = self.xml_root.find(f"./output-placements/output-placement[@uri='" + artifact.uri + "']")
         if not placement_node:
             placement_node = ETree.SubElement(placement_root, "output-placement", {"uri": artifact.uri})
         location_subnode = ETree.SubElement(placement_node, "location")


### PR DESCRIPTION
prevents error "Duplicate Artifact" from clarity when updating a placement without clearing first