### PR TITLE
Enable automated unit testing for Python 3.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,27 @@ jobs:
         with:
           coverage-reporter-version: v0.6.6
 
+  # Use a container to run Python 3.5 (host OS doesn't matter)
+  # required because of SSL cert errors in pip when running in the setup-python action
+  # Don't bother with coveralls here, just run the tests
+  test-python35:
+    runs-on: ubuntu-latest
+    container: python:3.5.10-buster
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Before tests (same as "before_install")
+        run: |
+          pip install --upgrade -r requirements.txt
+      - name: Run test suite (same as "script")
+        run: |
+          pytest --cov=s4
+
   # Use a container to run Python 2 (host OS doesn't matter)
   # required because the setup-python action dropped support for python 2
-  # Don't bother with coveralls or pypi here, just run the tests
+  # Don't bother with coveralls here, just run the tests
   test-python2:
     runs-on: ubuntu-latest
     container: python:2.7.18-buster


### PR DESCRIPTION
The `setup.py` file declares compatibility with Python 3.5, so we should be testing with it as well. 

(However, I don't think we have any customers using a Python version that old, and we should probably drop support for it in 2.0)