### PR TITLE
Attempt to fix coveralls parallel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,17 @@ jobs:
       - name: Coveralls
         uses: coverallsapp/github-action@v2.3.0
         with:
+          parallel: true
           coverage-reporter-version: v0.6.6
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close parallel build
+        uses: coverallsapp/github-action@v2.3.0
+        with:
+          parallel-finished: true
 
   # Use a container to run Python 3.5 (host OS doesn't matter)
   # required because of SSL cert errors in pip when running in the setup-python action


### PR DESCRIPTION
I have no idea why but coveralls suddenly started complaining about trying to add a job to a closed build on Joe's recent PR: https://github.com/SemaphoreSolutions/s4-clarity-lib/actions/runs/9665998764/job/26664659081#step:7:86

Trying to reconfigure the integration using the instructions at https://docs.coveralls.io/parallel-builds to see if that makes any difference. If not I might just disable it outright.