### PR TITLE
StepRunner support for running the same step multiple times within a protocol

### DIFF
--- a/s4/clarity/configuration/protocol.py
+++ b/s4/clarity/configuration/protocol.py
@@ -3,6 +3,7 @@
 
 import logging
 
+from s4.clarity._internal.factory import MultipleMatchingElements
 from s4.clarity._internal.element import ClarityElement, WrappedXml
 from s4.clarity.reagent_kit import ReagentKit
 from s4.clarity.control_type import ControlType
@@ -44,10 +45,16 @@ class Protocol(ClarityElement):
         """
         :rtype: StepConfiguration or None
         """
-        for step in self.steps:
-            if step.name == name:
-                return step
-        return None
+        candidate_steps = [step for step in self.steps if step.name == name]
+        if len(candidate_steps) == 1:
+            return candidate_steps[0]
+        elif len(candidate_steps) < 1:
+            return None
+        else:  # found more than 1 step with the same name
+            raise MultipleMatchingElements(
+                "Multiple steps were found with the name '%s' in the protocol "
+                "'%s'" % (name, self.name)
+            )
 
     @property
     def number_of_steps(self):

--- a/s4/clarity/steputils/step_runner.py
+++ b/s4/clarity/steputils/step_runner.py
@@ -9,6 +9,7 @@ import logging
 from s4.clarity import ETree, lazy_property
 from s4.clarity.step import Step
 from s4.clarity import ClarityException
+from s4.clarity._internal.factory import MultipleMatchingElements
 
 log = logging.getLogger(__name__)
 
@@ -44,8 +45,9 @@ class StepRunner:
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, lims, protocolname, stepconfigname, usequeuedinputs=True, numberofinputs=4):
+    def __init__(self, lims, protocolname, stepconfigname, usequeuedinputs=True, numberofinputs=4, protocolstepid=None):
         self.step = None
+        self.protocolstepid = protocolstepid
 
         self.lims = lims
         if self.lims is None:
@@ -71,7 +73,13 @@ class StepRunner:
         """
         try:
             protocol_config = self.lims.protocols.get_by_name(self.protocolname)
-            step = protocol_config.step(self.stepconfigname)
+            try:
+                step = protocol_config.step(self.stepconfigname)
+            except MultipleMatchingElements:
+                if self.protocolstepid:
+                    step = protocol_config.step_from_id(str(self.protocolstepid))
+                else:
+                    raise
         except ClarityException as ex:
             log.error("StepRunner could not load step configuration: %s" % str(ex))
             raise Exception("Configuration for step %s in protocol %s could not be located." % (self.stepconfigname, self.protocolname))


### PR DESCRIPTION
Fixes #69 

If the same step, with the same name, appears multiple times in a single protocol, it is now possible to test using a StepRunner, by instantiating the StepRunner with the new `protocolstepid` parameter with the ID of the step.

Example:
```
# Get the step IDs belonging to each instance of STEP_NAME in PROTOCOL_NAME
step_ids = []
protocol_config = self.lims.protocols.get_by_name(PROTOCOL_NAME)
for step in protocol_config.steps:
    if step.name == STEP_NAME:
        step_ids.append(step.uri.split('/')[-1])

# Run first instance of step
step_runner_1 = ExampleStepRunner(self.lims, protocolstepid=step_ids[0])
step_runner_1.run(inputuris=ARTIFACT_URIS)

# Run second instance of step
step_runner_2 = ExampleStepRunner(self.lims, protocolstepid=step_ids[1])
step_runner_2.run(previousstep=step_runner_1.step)
```

If `protocolstepid` is not provided then the StepRunner will raise an exception explaining that multiple steps with the same name were found in the protocol (and that it doesn't know which one you want).