### PR TITLE
Support the Leave in QC Protocol next step action

### DIFF
--- a/s4/clarity/step.py
+++ b/s4/clarity/step.py
@@ -29,6 +29,7 @@ REWORK_ACTION = "rework"
 REVIEW_ACTION = "review"
 STORE_ACTION = "store"
 NEXT_STEP_ACTION = "nextstep"
+LEAVE_IN_QC_PROTOCOL_ACTION = "leave"
 
 PROGRAM_STATUS_ERROR = "ERROR"
 PROGRAM_STATUS_RUNNING = "RUNNING"
@@ -251,6 +252,12 @@ class ArtifactAction(WrappedXml):
     def __init__(self, lims, step, xml_root):
         super(ArtifactAction, self).__init__(lims, xml_root)
         self.step = step
+
+    def leave_in_qc_protocol(self):
+        """
+        Sets the Next Step property for the artifact specified by artifact_uri to 'Leave in QC Protocol'
+        """
+        self._set_artifact_next_action(LEAVE_IN_QC_PROTOCOL_ACTION)
 
     def remove_from_workflow(self):
         """


### PR DESCRIPTION
Fixes #68

You can now call `self.step.actions.artifact_actions[artifact].leave_in_qc_protocol()` to set the artifact action on the Next Steps screen to "Leave in QC Protocol".