### PR TITLE
Add parents lazy property

### DIFF
--- a/s4/clarity/artifact.py
+++ b/s4/clarity/artifact.py
@@ -54,7 +54,7 @@ class Artifact(FieldsMixin, ClarityElement):
     @lazy_property
     def parents(self):
         """:type: list[Artifact]"""
-        if len(self.parent_process.outputs) == 0:  # a no-output step
+        if not self.parent_process or len(self.parent_process.outputs) == 0:  # no parent or no-output step
             return []
         iomap = self.parent_process.iomaps_output_keyed()
         return iomap[self]


### PR DESCRIPTION
Enables the ability to quickly get the parent artifact(s) of a given artifact by simply calling `.parents`

It is possible that there will be more than 1 parent, so parents should be plural.