### PR TITLE
Bugfix: Add string comparison for InstrumentType

### DIFF
--- a/s4/clarity/configuration/instrument_type.py
+++ b/s4/clarity/configuration/instrument_type.py
@@ -4,6 +4,7 @@
 from s4.clarity._internal import ClarityElement
 from s4.clarity._internal.props import subnode_links, subnode_property
 from .process_type import ProcessType
+from typing import Union
 
 
 class InstrumentType(ClarityElement):
@@ -17,14 +18,14 @@ class InstrumentType(ClarityElement):
     vendor = subnode_property("vendor")
     process_types = subnode_links(ProcessType, "process-type", "process-types")
 
-    def __eq__(self, other: str | ClarityElement | object) -> bool:
+    def __eq__(self, other: Union[str, ClarityElement, object]) -> bool:
         if isinstance(other, str):
             return self.name == other
         elif isinstance(other, ClarityElement):
             return self.uri == other.uri
         return False
 
-    def __ne__(self, other: str | ClarityElement | object) -> bool:
+    def __ne__(self, other: Union[str, ClarityElement, object]) -> bool:
         if isinstance(other, str):
             return self.name != other
         elif isinstance(other, ClarityElement):

--- a/s4/clarity/configuration/instrument_type.py
+++ b/s4/clarity/configuration/instrument_type.py
@@ -16,3 +16,17 @@ class InstrumentType(ClarityElement):
     name = subnode_property("name")
     vendor = subnode_property("vendor")
     process_types = subnode_links(ProcessType, "process-type", "process-types")
+
+    def __eq__(self, other: str | ClarityElement | object) -> bool:
+        if isinstance(other, str):
+            return self.name == other
+        elif isinstance(other, ClarityElement):
+            return self.uri == other.uri
+        return False
+
+    def __ne__(self, other: str | ClarityElement | object) -> bool:
+        if isinstance(other, str):
+            return self.name != other
+        elif isinstance(other, ClarityElement):
+            return self.uri != other.uri
+        return True

--- a/s4/clarity/configuration/instrument_type.py
+++ b/s4/clarity/configuration/instrument_type.py
@@ -4,7 +4,6 @@
 from s4.clarity._internal import ClarityElement
 from s4.clarity._internal.props import subnode_links, subnode_property
 from .process_type import ProcessType
-from typing import Union
 
 
 class InstrumentType(ClarityElement):
@@ -18,14 +17,36 @@ class InstrumentType(ClarityElement):
     vendor = subnode_property("vendor")
     process_types = subnode_links(ProcessType, "process-type", "process-types")
 
-    def __eq__(self, other: Union[str, ClarityElement, object]) -> bool:
+    def __eq__(self, other):
+        """comparison operator overloading,
+        If it's a string, check against the name, otherwise check against its URI.
+        This allows for backwards compatibility with the old `Instrument.instrument_type` which is a string.
+        An issue in v1.6.0 - in which the `Instrument.instrument_type` was a string.
+
+        Args:
+            other (str | ClarityElement | object): the other object to compare against
+
+        Returns:
+            bool: True if the instrument type is equal to the other object, False otherwise
+        """
         if isinstance(other, str):
             return self.name == other
         elif isinstance(other, ClarityElement):
             return self.uri == other.uri
         return False
 
-    def __ne__(self, other: Union[str, ClarityElement, object]) -> bool:
+    def __ne__(self, other):
+        """comparison operator overloading,
+        If it's a string, check against the name, otherwise check against its URI.
+        This allows for backwards compatibility with the old `Instrument.instrument_type` which is a string.
+        An issue in v1.6.0 - in which the `Instrument.instrument_type` was a string.
+
+        Args:
+            other (str | ClarityElement | object): the other object to compare against
+
+        Returns:
+            bool: True if the instrument type is not equal to the other object, False otherwise
+        """
         if isinstance(other, str):
             return self.name != other
         elif isinstance(other, ClarityElement):


### PR DESCRIPTION
In older versions of this s4 packages, example, v1.6.0, the Instrument.instrument_type is a string. 
So older s4 libraries does this sort of comparison:

```
bravo.instrument_type == "bravo"
```

But in the newer s4 packages, this comparison fails, because it's a string to object comparison. The user could update scripts, but sometimes that is not feasible.

Simple solution: set the comparison, when it is a string, to compare against its name, which is more intuitive. 

This allows for backwards compatibility.
If doing an object-to-object comparison, it still does a comparison against URI, which is a source of truth.