### PR TITLE
Add abort_step method to StepRunner class

### DIFF
--- a/s4/clarity/steputils/step_runner.py
+++ b/s4/clarity/steputils/step_runner.py
@@ -657,6 +657,10 @@ class StepRunner:
             )
 
         return session
+        
+    def abort_step(self):
+        """Aborts the current step"""
+        self.lims.steps.delete(self.step)
 
 class StepRunnerException(Exception):
     pass


### PR DESCRIPTION
Allows the StepRunner class to abort itself when called `self.abort_step`