### PR TITLE
Enable control_types to be queryable

### DIFF
--- a/s4/clarity/lims.py
+++ b/s4/clarity/lims.py
@@ -122,7 +122,7 @@ class LIMS(object):
 
         self.projects = ElementFactory(self, Project, batch_flags=BatchFlags.QUERY)
 
-        self.control_types = ElementFactory(self, ControlType)
+        self.control_types = ElementFactory(self, ControlType, batch_flags=BatchFlags.QUERY)
 
         self.queues = ElementFactory(self, Queue)
 


### PR DESCRIPTION
Set batch_flag on control_types so that control_types is queryable.

```
lims.control_types.get_by_name('some-control-name')
lims.control_types.query(name=['some-control-name', 'another-control-name'])
```